### PR TITLE
Add a Node Kernel reconciler

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,8 +3,8 @@ name: e2e
 on: [pull_request]
 
 jobs:
-  e2e:
-    name: Prebuilt kernel module
+  e2e-nfd-labeling:
+    name: Prebuilt kernel module - NFD labeling
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,10 +43,93 @@ jobs:
       - name: Deploy OOTO
         run: make deploy
         env:
-          IMG: ooto:local
+          KUSTOMIZE_CONFIG_DEFAULT: ci/install-nfd-labeling
 
-      - name: Set the OOTO manager's pull policy to Never
-        run: kubectl patch deployments.apps -n oot-operator-system oot-operator-controller-manager --patch-file ci/patch-ooto-manager-pullpolicy.yml
+      - name: Check that the ooto_ci module is not loaded on the node
+        run: |
+          if minikube ssh -- lsmod | grep ooto_ci; then
+            echo "Unexpected lsmod output - the module should not be loaded"
+            exit 1
+          fi
+
+      - name: Add an ooto-ci Module that contains a mapping for $KERNEL_VERSION
+        run: |
+          sed "s/KVER_CHANGEME/${KERNEL_VERSION}/g" ci/module-ooto-ci.template.yaml | tee module-ooto-ci.yaml
+          kubectl apply -f module-ooto-ci.yaml
+
+      - name: Check that the module gets loaded on the node
+        run: |
+          until minikube ssh -- lsmod | grep ooto_ci; do
+            sleep 3
+          done
+        timeout-minutes: 1
+
+      - name: Remove the Module
+        run: kubectl delete -f module-ooto-ci.yaml
+
+      - name: Check that the module gets unloaded from the node
+        run: |
+          until ! minikube ssh -- lsmod | grep ooto_ci; do
+            sleep 3
+          done
+        timeout-minutes: 1
+
+      - name: Describe the DaemonSet
+        run: kubectl describe daemonset -l oot.node.kubernetes.io/module.name=ooto-ci
+        continue-on-error: true # if the job succeeded, the DaemonSet might be gone already
+        if: ${{ always() }}
+
+      - name: Describe the Pod
+        run: kubectl describe pod -l oot.node.kubernetes.io/module.name=ooto-ci
+        continue-on-error: true # if the job succeeded, the pod might be gone already
+        if: ${{ always() }}
+
+      - name: Collect dmesg
+        run: sudo dmesg
+        if: ${{ always() }}
+
+      - name: Get all operator logs
+        run: kubectl logs deployment.apps/oot-operator-controller-manager -n oot-operator-system
+        if: ${{ always() }}
+
+  e2e-ooto-labeling:
+    name: Prebuilt kernel module - OOTO labeling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Save the kernel version
+        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
+
+      - name: Build the kernel module
+        run: make KERNEL_SRC_DIR="/usr/src/linux-headers-${KERNEL_VERSION}"
+        working-directory: ci/ooto-kmod
+
+      - name: Download and install minikube
+        run: |
+          wget https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+          sudo dpkg -i ./minikube_latest_amd64.deb
+
+      - name: Start minikube and wait until CoreDNS is available
+        run: |
+          minikube start --driver=docker
+          kubectl wait --for=condition=available deployment coredns -n kube-system
+
+      - name: Build ooto-kmod
+        run: minikube image build -t ooto-kmod:local --build-opt build-arg=KERNEL_VERSION=${KERNEL_VERSION} ci/ooto-kmod
+
+      - name: Build OOTO
+        run: minikube image build -t ooto:local .
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.6
+
+      - name: Deploy OOTO
+        run: make deploy
+        env:
+          KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci
 
       - name: Check that the ooto_ci module is not loaded on the node
         run: |

--- a/Makefile
+++ b/Makefile
@@ -150,14 +150,16 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+KUSTOMIZE_CONFIG_DEFAULT ?= config/default
+
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build $(KUSTOMIZE_CONFIG_DEFAULT) | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build $(KUSTOMIZE_CONFIG_DEFAULT) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen

--- a/ci/install-ci/kustomization.yaml
+++ b/ci/install-ci/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../config/default
+
+images:
+  - name: controller
+    newName: ooto
+    newTag: local
+
+patchesStrategicMerge:
+  - |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: controller-manager
+      namespace: system
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              imagePullPolicy: Never

--- a/ci/install-nfd-labeling/kustomization.yaml
+++ b/ci/install-nfd-labeling/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../install-ci
+
+patchesStrategicMerge:
+  - |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: controller-manager
+      namespace: system
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              env:
+              - name: KERNEL_LABELING_METHOD
+                value: nfd

--- a/ci/patch-ooto-manager-pullpolicy.yml
+++ b/ci/patch-ooto-manager-pullpolicy.yml
@@ -1,6 +1,0 @@
-spec:
-  template:
-    spec:
-      containers:
-        - name: manager
-          imagePullPolicy: Never

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,7 +21,9 @@ rules:
   resources:
   - nodes
   verbs:
+  - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ooto.sigs.k8s.io

--- a/controllers/daemonset.go
+++ b/controllers/daemonset.go
@@ -19,14 +19,18 @@ type DaemonSetCreator interface {
 }
 
 type daemonSetGenerator struct {
-	scheme *runtime.Scheme
+	kernelLabel string
+	scheme      *runtime.Scheme
 }
 
-func NewDaemonSetCreator(scheme *runtime.Scheme) *daemonSetGenerator {
-	return &daemonSetGenerator{scheme: scheme}
+func NewDaemonSetCreator(kernelLabel string, scheme *runtime.Scheme) *daemonSetGenerator {
+	return &daemonSetGenerator{
+		kernelLabel: kernelLabel,
+		scheme:      scheme,
+	}
 }
 
-func (dc daemonSetGenerator) SetAsDesired(ds *appsv1.DaemonSet, image string, mod *ootov1beta1.Module, kernelVersion string) error {
+func (dc *daemonSetGenerator) SetAsDesired(ds *appsv1.DaemonSet, image string, mod *ootov1beta1.Module, kernelVersion string) error {
 	if ds == nil {
 		return errors.New("ds cannot be nil")
 	}
@@ -61,7 +65,7 @@ func (dc daemonSetGenerator) SetAsDesired(ds *appsv1.DaemonSet, image string, mo
 	ds.SetLabels(labels)
 
 	nodeSelector := CopyMapStringString(mod.Spec.Selector)
-	nodeSelector[KernelLabel] = kernelVersion
+	nodeSelector[dc.kernelLabel] = kernelVersion
 
 	driverContainer := mod.Spec.DriverContainer
 	driverContainer.Name = "driver-container"

--- a/controllers/daemonset_test.go
+++ b/controllers/daemonset_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 var _ = Describe("daemonSetGenerator", func() {
+	const kernelLabel = "kernel-label"
+
 	Describe("SetAsDesired", func() {
-		dg := controllers.NewDaemonSetCreator(scheme)
+		dg := controllers.NewDaemonSetCreator(kernelLabel, scheme)
 
 		It("should return an error if the DaemonSet is nil", func() {
 			Expect(
@@ -110,7 +112,7 @@ var _ = Describe("daemonSetGenerator", func() {
 							},
 							NodeSelector: map[string]string{
 								"has-feature-x": "true",
-								"feature.node.kubernetes.io/kernel-version.full": kernelVersion,
+								kernelLabel:     kernelVersion,
 							},
 						},
 					},

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -32,8 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const KernelLabel = "feature.node.kubernetes.io/kernel-version.full"
-
 // ModuleReconciler reconciles a Module object
 type ModuleReconciler struct {
 	client.Client

--- a/controllers/node_kernel_reconciler.go
+++ b/controllers/node_kernel_reconciler.go
@@ -1,0 +1,68 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;patch;watch
+
+type NodeKernelReconciler struct {
+	client    client.Client
+	labelName string
+}
+
+func NewNodeKernelReconciler(client client.Client, labelName string) *NodeKernelReconciler {
+	return &NodeKernelReconciler{
+		client:    client,
+		labelName: labelName,
+	}
+}
+
+func (r *NodeKernelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	node := v1.Node{}
+
+	logger := log.FromContext(ctx)
+
+	if err := r.client.Get(ctx, types.NamespacedName{Name: req.Name}, &node); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Node not found; probably deleted")
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{Requeue: true}, fmt.Errorf("could not get node: %v", err)
+	}
+
+	labelValue := node.Labels[r.labelName]
+	kernelVersion := node.Status.NodeInfo.KernelVersion
+
+	if labelValue != kernelVersion {
+		logger.Info("Patching node label", "old kernel", labelValue, "new kernel", kernelVersion)
+
+		p := client.MergeFrom(node.DeepCopy())
+
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+
+		node.Labels[r.labelName] = node.Status.NodeInfo.KernelVersion
+
+		if err := r.client.Patch(ctx, &node, p); err != nil {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("could not patch the node: %v", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NodeKernelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&v1.Node{}).Complete(r)
+}

--- a/controllers/node_kernel_reconciler_test.go
+++ b/controllers/node_kernel_reconciler_test.go
@@ -1,0 +1,94 @@
+package controllers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/qbarrand/oot-operator/controllers"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("NodeKernelReconciler", func() {
+	Describe("Reconcile", func() {
+		const (
+			kernelVersion = "1.2.3"
+			labelName     = "label-name"
+			nodeName      = "node-name"
+		)
+
+		It("should do nothing if the node does not exist anymore", func() {
+			nkr := controllers.NewNodeKernelReconciler(fake.NewClientBuilder().Build(), labelName)
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: nodeName},
+			}
+
+			res, err := nkr.Reconcile(context.TODO(), req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(res))
+		})
+
+		It("should set the label if it does not exist", func() {
+			node := v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithObjects(&node).Build()
+
+			nkr := controllers.NewNodeKernelReconciler(client, labelName)
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: nodeName},
+			}
+
+			ctx := context.TODO()
+
+			res, err := nkr.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(res))
+
+			updatedNode := v1.Node{}
+
+			err = client.Get(ctx, types.NamespacedName{Name: nodeName}, &updatedNode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedNode.Labels).To(HaveKeyWithValue(labelName, kernelVersion))
+		})
+
+		It("should set the label if it already exists", func() {
+			node := v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{kernelVersion: "4.5.6"},
+				},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithObjects(&node).Build()
+
+			nkr := controllers.NewNodeKernelReconciler(client, labelName)
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: nodeName},
+			}
+
+			ctx := context.TODO()
+
+			res, err := nkr.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(res))
+
+			updatedNode := v1.Node{}
+
+			err = client.Get(ctx, types.NamespacedName{Name: nodeName}, &updatedNode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedNode.Labels).To(HaveKeyWithValue(labelName, kernelVersion))
+		})
+	})
+})

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Main Suite")
+}
+
+var _ = Describe("GetEnvWithDefault", func() {
+	const envVar = "_OOTO_TEST_PRIVATE_VAR"
+
+	It("should return the default value if the variable is undefined", func() {
+		const def = "some-default"
+
+		res := GetEnvWithDefault(envVar, def)
+
+		Expect(res).To(Equal(def))
+	})
+
+	It("should return the environment variable if it is defined", func() {
+		const value = "some-value"
+
+		GinkgoT().Setenv(envVar, value)
+
+		res := GetEnvWithDefault(envVar, "some-default")
+
+		Expect(res).To(Equal(value))
+	})
+})


### PR DESCRIPTION
This PR adds a new, optional reconciler that labels nodes with the contents of `.status.nodeInfo.kernelVersion`. Contrary to NFD, it does not deploy any additional resource since all the required data is already in the API server.