### PR TITLE
Make it possible to specify a service account for the pod

### DIFF
--- a/api/v1alpha1/module_types.go
+++ b/api/v1alpha1/module_types.go
@@ -114,6 +114,11 @@ type ModuleSpec struct {
 
 	// Selector describes on which nodes the Module should be loaded.
 	Selector map[string]string `json:"selector"`
+
+	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // ModuleStatus defines the observed state of Module.

--- a/config/crd/bases/ooto.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/ooto.sigs.k8s.io_modules.yaml
@@ -4044,6 +4044,10 @@ spec:
                 description: Selector describes on which nodes the Module should be
                   loaded.
                 type: object
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the ServiceAccount
+                  to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                type: string
             required:
             - driverContainer
             - kernelMappings

--- a/controllers/daemonset.go
+++ b/controllers/daemonset.go
@@ -210,9 +210,10 @@ func (dc *daemonSetGenerator) SetAsDesired(ds *appsv1.DaemonSet, image string, m
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: standardLabels},
 			Spec: v1.PodSpec{
-				NodeSelector: nodeSelector,
-				Containers:   containers,
-				Volumes:      volumes,
+				NodeSelector:       nodeSelector,
+				Containers:         containers,
+				ServiceAccountName: mod.Spec.ServiceAccountName,
+				Volumes:            volumes,
 			},
 		},
 	}

--- a/controllers/daemonset_test.go
+++ b/controllers/daemonset_test.go
@@ -89,6 +89,7 @@ var _ = Describe("daemonSetGenerator", func() {
 				devicePluginImage    = "device-plugin-image"
 				driverContainerImage = "driver-image"
 				dsName               = "ds-name"
+				serviceAccountName   = "some-service-account"
 			)
 
 			dcVolMount := v1.VolumeMount{
@@ -119,7 +120,8 @@ var _ = Describe("daemonSetGenerator", func() {
 						Image:        devicePluginImage,
 						VolumeMounts: []v1.VolumeMount{dpVolMount},
 					},
-					Selector: map[string]string{"has-feature-x": "true"},
+					Selector:           map[string]string{"has-feature-x": "true"},
+					ServiceAccountName: serviceAccountName,
 				},
 			}
 
@@ -197,6 +199,7 @@ var _ = Describe("daemonSetGenerator", func() {
 								"has-feature-x": "true",
 								kernelLabel:     kernelVersion,
 							},
+							ServiceAccountName: serviceAccountName,
 							Volumes: []v1.Volume{
 								{
 									Name: "node-lib-modules",


### PR DESCRIPTION
This PR makes it possible to specify which `ServiceAccount` will run the DaemonSet / DevicePlugin pods. 