### PR TITLE
Build the DriverContainer image on the node that runs minikube

### DIFF
--- a/.github/actions/build-drivercontainer-image/action.yml
+++ b/.github/actions/build-drivercontainer-image/action.yml
@@ -1,0 +1,25 @@
+name: Build DriverContainer image
+
+description: This action builds a DriverContainer image for CI
+
+inputs:
+  kernel-version:
+    required: true
+    description: The kernel version against which the module should be built
+
+runs:
+  using: composite
+
+  steps:
+    - name: Build the kernel module
+      run: make KERNEL_SRC_DIR="/usr/src/linux-headers-${{ inputs.kernel-version }}"
+      working-directory: ci/ooto-kmod
+      shell: bash
+
+    - name: Build the image
+      run: docker build -t ooto-kmod:local --build-arg=KERNEL_VERSION=${{ inputs.kernel-version }} ci/ooto-kmod
+      shell: bash
+
+    - name: Export the image
+      run: docker save -o ooto-kmod_local.tar ooto-kmod:local
+      shell: bash

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,36 +29,6 @@ jobs:
           path: ooto_local.tar
           retention-days: 1
 
-  build-drivercontainer-image:
-    runs-on: ubuntu-latest
-
-    name: Build the DriverContainer image
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Save the kernel version
-        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
-
-      - name: Build the kernel module
-        run: make KERNEL_SRC_DIR="/usr/src/linux-headers-${KERNEL_VERSION}"
-        working-directory: ci/ooto-kmod
-
-      - name: Build the image
-        run: docker build -t ooto-kmod:local --build-arg=KERNEL_VERSION=${KERNEL_VERSION} ci/ooto-kmod
-
-      - name: Export the image
-        run: docker save -o ooto-kmod_local.tar ooto-kmod:local
-
-      - name: Upload the image
-        uses: actions/upload-artifact@v3
-        with:
-          name: ci-images
-          path: ooto-kmod_local.tar
-          if-no-files-found: error
-          retention-days: 1
-
   e2e:
     runs-on: ubuntu-latest
 
@@ -72,7 +42,7 @@ jobs:
 
     name: "Prebuilt kernel module (NFD: ${{ matrix.install-nfd }})"
 
-    needs: [build-operator-image, build-drivercontainer-image]
+    needs: [build-operator-image]
 
     steps:
       - name: Checkout
@@ -92,6 +62,14 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ci-images
+
+      - name: Save the kernel version
+        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
+
+      - name: Build the DriverContainer image
+        uses: ./.github/actions/build-drivercontainer-image
+        with:
+          kernel-version: ${{ env.KERNEL_VERSION }}
 
       - name: Import images into minikube
         run: |
@@ -167,7 +145,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [build-operator-image, build-drivercontainer-image]
+    needs: [build-operator-image]
 
     steps:
       - name: Checkout
@@ -182,6 +160,14 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ci-images
+
+      - name: Save the kernel version
+        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
+
+      - name: Build the DriverContainer image
+        uses: ./.github/actions/build-drivercontainer-image
+        with:
+          kernel-version: ${{ env.KERNEL_VERSION }}
 
       - name: Import images into minikube
         run: |
@@ -220,8 +206,6 @@ jobs:
 
       - name: Create one Module for each node
         run: |
-          KERNEL_VERSION="$(uname -r)"
-
           # Node minikube gets module a
           sed -e s/NAME_CHANGEME/ooto-ci-a/g \
             -e s/KMOD_CHANGEME/ooto_ci_a/g \
@@ -283,7 +267,7 @@ jobs:
 
     name: In-cluster build
 
-    needs: [build-operator-image, build-drivercontainer-image]
+    needs: [build-operator-image]
 
     steps:
       - name: Checkout
@@ -306,6 +290,14 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ci-images
+
+      - name: Save the kernel version
+        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
+
+      - name: Build the DriverContainer image
+        uses: ./.github/actions/build-drivercontainer-image
+        with:
+          kernel-version: ${{ env.KERNEL_VERSION }}
 
       - name: Import DriverContainer base into the internal-registry
         run: |


### PR DESCRIPTION
This avoids mismatches where the node that builds the DriverContainer does not run the same kernel as the node that runs minikube. It should fix current CI issues.