### PR TITLE
Adding support for variable substituation in kernelmapping fields

### DIFF
--- a/controllers/module/kernelmapper.go
+++ b/controllers/module/kernelmapper.go
@@ -1,17 +1,41 @@
 package module
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
+	"strings"
 
+	"github.com/a8m/envsubst/parse"
 	ootov1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 )
+
+const (
+	kernelVersionMajorIdx = 0
+	kernelVersionMinorIdx = 1
+	kernelVersionPatchIdx = 2
+)
+
+type NodeOSConfig struct {
+	kernelFullVersion  string `subst:"KERNEL_FULL_VERSION"`
+	kernelVersionMMP   string `subst:"KERNEL_XYZ"`
+	kernelVersionMajor string `subst:"KERNEL_X"`
+	kernelVersionMinor string `subst:"KERNEL_Y"`
+	kernelVersionPatch string `subst:"KERNEL_Z"`
+	kernelRHELVersion  string `subst:"KERNEL_RHEL_VERSION"`
+	kernelRHELRelease  string `subst:"KERNEL_RHEL_RELEASE"`
+	kernelRHELArch     string `subst:"KERNEL_RHEL_ARCH"`
+}
 
 //go:generate mockgen -source=kernelmapper.go -package=module -destination=mock_kernelmapper.go
 
 type KernelMapper interface {
 	FindMappingForKernel(mappings []ootov1alpha1.KernelMapping, kernelVersion string) (*ootov1alpha1.KernelMapping, error)
+	GetNodeOSConfig(node *v1.Node) *NodeOSConfig
+	PrepareKernelMapping(mapping *ootov1alpha1.KernelMapping, osConfig *NodeOSConfig) (*ootov1alpha1.KernelMapping, error)
 }
 
 type kernelMapper struct{}
@@ -22,7 +46,7 @@ func NewKernelMapper() KernelMapper {
 
 // FindMappingForKernel tries to match kernelVersion against mappings. It returns the first mapping that has a Literal
 // field equal to kernelVersion or a Regexp field that matches kernelVersion.
-func (kernelMapper) FindMappingForKernel(mappings []ootov1alpha1.KernelMapping, kernelVersion string) (*ootov1alpha1.KernelMapping, error) {
+func (k *kernelMapper) FindMappingForKernel(mappings []ootov1alpha1.KernelMapping, kernelVersion string) (*ootov1alpha1.KernelMapping, error) {
 	for _, m := range mappings {
 		if m.Literal != "" && m.Literal == kernelVersion {
 			return &m, nil
@@ -40,4 +64,52 @@ func (kernelMapper) FindMappingForKernel(mappings []ootov1alpha1.KernelMapping, 
 	}
 
 	return nil, errors.New("no suitable mapping found")
+}
+
+func (k *kernelMapper) GetNodeOSConfig(node *v1.Node) *NodeOSConfig {
+	osConfig := NodeOSConfig{}
+
+	osConfigFieldsList := regexp.MustCompile("[.,-]").Split(node.Status.NodeInfo.KernelVersion, -1)
+
+	osConfig.kernelFullVersion = node.Status.NodeInfo.KernelVersion
+	osConfig.kernelVersionMMP = strings.Join(osConfigFieldsList[:kernelVersionPatchIdx+1], ".")
+	osConfig.kernelVersionMajor = osConfigFieldsList[kernelVersionMajorIdx]
+	osConfig.kernelVersionMinor = osConfigFieldsList[kernelVersionMinorIdx]
+	osConfig.kernelVersionPatch = osConfigFieldsList[kernelVersionPatchIdx]
+
+	// [TODO] - remove this code from upstream once we have it in downstream
+	if strings.Contains(node.Status.NodeInfo.OSImage, "Red Hat") {
+		osConfig.kernelRHELVersion = osConfigFieldsList[len(osConfigFieldsList)-2]
+		osConfig.kernelRHELRelease = strings.Join(osConfigFieldsList[kernelVersionPatchIdx+1:len(osConfigFieldsList)-1], ".")
+		osConfig.kernelRHELArch = osConfigFieldsList[len(osConfigFieldsList)-1]
+	}
+	// [TODO] - add debian and Ubuntu handling
+	return &osConfig
+}
+
+func (k *kernelMapper) PrepareKernelMapping(mapping *ootov1alpha1.KernelMapping, osConfig *NodeOSConfig) (*ootov1alpha1.KernelMapping, error) {
+	mappingString, err := json.Marshal(mapping)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal mapping: %w", err)
+	}
+	osConfigStrings := k.prepareOSConfigList(*osConfig)
+	parser := parse.New("mapping", osConfigStrings, &parse.Restrictions{})
+	parsedMapping, err := parser.Parse(string(mappingString))
+	if err != nil {
+		return nil, fmt.Errorf("failed to substitute the os config into mapping: %w", err)
+	}
+	substMapping := ootov1alpha1.KernelMapping{}
+	err = json.Unmarshal([]byte(parsedMapping), &substMapping)
+	return &substMapping, err
+}
+
+func (k *kernelMapper) prepareOSConfigList(osConfig NodeOSConfig) []string {
+	t := reflect.TypeOf(osConfig)
+	v := reflect.ValueOf(osConfig)
+
+	varList := make([]string, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		varList[i] = t.Field(i).Tag.Get("subst") + "=" + v.Field(i).String()
+	}
+	return varList
 }

--- a/controllers/module/kernelmapper_test.go
+++ b/controllers/module/kernelmapper_test.go
@@ -4,63 +4,144 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ootov1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("KernelMapper", func() {
+var _ = Describe("FindMappingForKernel", func() {
+	const (
+		kernelVersion = "1.2.3"
+		selectedImage = "image1"
+	)
+
 	km := NewKernelMapper()
 
-	Describe("FindMappingForKernel", func() {
-		const (
-			kernelVersion = "1.2.3"
-			selectedImage = "image1"
-		)
+	It("should work with one literal mapping", func() {
+		mapping := ootov1alpha1.KernelMapping{
+			ContainerImage: selectedImage,
+			Literal:        "1.2.3",
+		}
 
-		It("should work with one literal mapping", func() {
-			mapping := ootov1alpha1.KernelMapping{
+		m, err := km.FindMappingForKernel([]ootov1alpha1.KernelMapping{mapping}, kernelVersion)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(Equal(&mapping))
+	})
+
+	It("should work with one regexp mapping", func() {
+		mapping := ootov1alpha1.KernelMapping{
+			ContainerImage: selectedImage,
+			Regexp:         `1\..*`,
+		}
+
+		m, err := km.FindMappingForKernel([]ootov1alpha1.KernelMapping{mapping}, kernelVersion)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(Equal(&mapping))
+	})
+
+	It("should return an error if a regex is invalid", func() {
+		mapping := ootov1alpha1.KernelMapping{
+			ContainerImage: selectedImage,
+			Regexp:         "invalid)",
+		}
+
+		_, err := km.FindMappingForKernel([]ootov1alpha1.KernelMapping{mapping}, kernelVersion)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error if no mapping work", func() {
+		mappings := []ootov1alpha1.KernelMapping{
+			{
 				ContainerImage: selectedImage,
-				Literal:        "1.2.3",
-			}
-
-			m, err := km.FindMappingForKernel([]ootov1alpha1.KernelMapping{mapping}, kernelVersion)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(m).To(Equal(&mapping))
-		})
-
-		It("should work with one regexp mapping", func() {
-			mapping := ootov1alpha1.KernelMapping{
+				Regexp:         `1.2.2`,
+			},
+			{
 				ContainerImage: selectedImage,
-				Regexp:         `1\..*`,
-			}
+				Regexp:         `0\..*`,
+			},
+		}
 
-			m, err := km.FindMappingForKernel([]ootov1alpha1.KernelMapping{mapping}, kernelVersion)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(m).To(Equal(&mapping))
-		})
+		_, err := km.FindMappingForKernel(mappings, kernelVersion)
+		Expect(err).To(MatchError("no suitable mapping found"))
+	})
+})
 
-		It("should return an error if a regex is invalid", func() {
-			mapping := ootov1alpha1.KernelMapping{
-				ContainerImage: selectedImage,
-				Regexp:         "invalid)",
-			}
+var _ = Describe("PrepareKernelMapping", func() {
+	km := NewKernelMapper()
+	osConfig := NodeOSConfig{
+		kernelFullVersion:  "kernelFullVersion",
+		kernelVersionMMP:   "kernelMMP",
+		kernelVersionMajor: "kernelMajor",
+		kernelVersionMinor: "kernelMinor",
+		kernelVersionPatch: "kernelPatch",
+		kernelRHELVersion:  "kernelVersion",
+		kernelRHELRelease:  "kernelRelease",
+		kernelRHELArch:     "kernelArch",
+	}
 
-			_, err := km.FindMappingForKernel([]ootov1alpha1.KernelMapping{mapping}, kernelVersion)
-			Expect(err).To(HaveOccurred())
-		})
+	It("error input", func() {
+		mapping := ootov1alpha1.KernelMapping{
+			ContainerImage: "some image:${KERNEL_XYZ",
+			Literal:        "some literal",
+			Regexp:         "regexp",
+		}
+		_, err := km.PrepareKernelMapping(&mapping, &osConfig)
+		Expect(err).To(HaveOccurred())
+	})
 
-		It("should return an error if no mapping work", func() {
-			mappings := []ootov1alpha1.KernelMapping{
-				{
-					ContainerImage: selectedImage,
-					Regexp:         `1.2.2`,
+	It("flow with replacement", func() {
+		mapping := ootov1alpha1.KernelMapping{
+			ContainerImage: "some image:${KERNEL_XYZ}",
+			Literal:        "some literal",
+			Regexp:         "regexp",
+			Build: &ootov1alpha1.Build{
+				BuildArgs: []ootov1alpha1.BuildArg{
+					{Name: "name1", Value: "value1"},
+					{Name: "kernel version", Value: "${KERNEL_FULL_VERSION}"},
 				},
-				{
-					ContainerImage: selectedImage,
-					Regexp:         `0\..*`,
+			},
+		}
+		expectMapping := ootov1alpha1.KernelMapping{
+			ContainerImage: "some image:kernelMMP",
+			Literal:        "some literal",
+			Regexp:         "regexp",
+			Build: &ootov1alpha1.Build{
+				BuildArgs: []ootov1alpha1.BuildArg{
+					{Name: "name1", Value: "value1"},
+					{Name: "kernel version", Value: "kernelFullVersion"},
 				},
-			}
+			},
+		}
 
-			_, err := km.FindMappingForKernel(mappings, kernelVersion)
-			Expect(err).To(MatchError("no suitable mapping found"))
-		})
+		res, err := km.PrepareKernelMapping(&mapping, &osConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*res).To(Equal(expectMapping))
+	})
+})
+
+var _ = Describe("GetNodeOSConfig", func() {
+	km := NewKernelMapper()
+
+	It("parsing the node data", func() {
+		node := v1.Node{
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{
+					KernelVersion: "4.18.0-305.45.1.el8_4.x86_64",
+					OSImage:       "Red Hat Enterprise Linux CoreOS 410.84.202205191234-0 (Ootpa)",
+				},
+			},
+		}
+
+		expectedOSConfig := NodeOSConfig{
+			kernelFullVersion:  "4.18.0-305.45.1.el8_4.x86_64",
+			kernelVersionMMP:   "4.18.0",
+			kernelVersionMajor: "4",
+			kernelVersionMinor: "18",
+			kernelVersionPatch: "0",
+			kernelRHELVersion:  "el8_4",
+			kernelRHELRelease:  "305.45.1.el8_4",
+			kernelRHELArch:     "x86_64",
+		}
+
+		res := km.GetNodeOSConfig(&node)
+		Expect(*res).To(Equal(expectedOSConfig))
 	})
 })

--- a/controllers/module/mock_kernelmapper.go
+++ b/controllers/module/mock_kernelmapper.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockKernelMapper is a mock of KernelMapper interface.
@@ -47,4 +48,33 @@ func (m *MockKernelMapper) FindMappingForKernel(mappings []v1alpha1.KernelMappin
 func (mr *MockKernelMapperMockRecorder) FindMappingForKernel(mappings, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMappingForKernel", reflect.TypeOf((*MockKernelMapper)(nil).FindMappingForKernel), mappings, kernelVersion)
+}
+
+// GetNodeOSConfig mocks base method.
+func (m *MockKernelMapper) GetNodeOSConfig(node *v1.Node) *NodeOSConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeOSConfig", node)
+	ret0, _ := ret[0].(*NodeOSConfig)
+	return ret0
+}
+
+// GetNodeOSConfig indicates an expected call of GetNodeOSConfig.
+func (mr *MockKernelMapperMockRecorder) GetNodeOSConfig(node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeOSConfig", reflect.TypeOf((*MockKernelMapper)(nil).GetNodeOSConfig), node)
+}
+
+// PrepareKernelMapping mocks base method.
+func (m *MockKernelMapper) PrepareKernelMapping(mapping *v1alpha1.KernelMapping, osConfig *NodeOSConfig) (*v1alpha1.KernelMapping, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareKernelMapping", mapping, osConfig)
+	ret0, _ := ret[0].(*v1alpha1.KernelMapping)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareKernelMapping indicates an expected call of PrepareKernelMapping.
+func (mr *MockKernelMapperMockRecorder) PrepareKernelMapping(mapping, osConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareKernelMapping", reflect.TypeOf((*MockKernelMapper)(nil).PrepareKernelMapping), mapping, osConfig)
 }

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -144,6 +144,8 @@ var _ = Describe("ModuleReconciler", func() {
 				},
 			}
 
+			osConfig := module.NodeOSConfig{}
+
 			mod := ootov1alpha1.Module{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      moduleName,
@@ -188,7 +190,9 @@ var _ = Describe("ModuleReconciler", func() {
 			}
 
 			gomock.InOrder(
+				mockKM.EXPECT().GetNodeOSConfig(&nodeList.Items[0]).Return(&osConfig),
 				mockKM.EXPECT().FindMappingForKernel(mappings, kernelVersion).Return(&mappings[0], nil),
+				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
 				mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, gomock.AssignableToTypeOf(mod)),
 				mockDC.EXPECT().SetDriverContainerAsDesired(context.TODO(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion),
 				mockDC.EXPECT().GarbageCollect(ctx, nil, sets.NewString(kernelVersion)),
@@ -210,6 +214,8 @@ var _ = Describe("ModuleReconciler", func() {
 				imageName     = "test-image"
 				kernelVersion = "1.2.3"
 			)
+
+			osConfig := module.NodeOSConfig{}
 
 			mappings := []ootov1alpha1.KernelMapping{
 				{
@@ -271,7 +277,9 @@ var _ = Describe("ModuleReconciler", func() {
 			dsByKernelVersion := map[string]*appsv1.DaemonSet{kernelVersion: &ds}
 
 			gomock.InOrder(
+				mockKM.EXPECT().GetNodeOSConfig(&nodeList.Items[0]).Return(&osConfig),
 				mockKM.EXPECT().FindMappingForKernel(mappings, kernelVersion).Return(&mappings[0], nil),
+				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
 				mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, gomock.AssignableToTypeOf(mod)).Return(dsByKernelVersion, nil),
 				mockDC.EXPECT().SetDriverContainerAsDesired(context.TODO(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion).Do(
 					func(ctx context.Context, d *appsv1.DaemonSet, _ string, _ ootov1alpha1.Module, _ string) {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/a8m/envsubst v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.16+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmU
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
+github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
+github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
This PR contains the following:
1) generating kernel data per node(full version, major/minor/patch numbers,
   RHEL release versions, architecture) based on values stored by the kubelet
   in the node Status field
2) substiting the template variables defined in the modules kernel mappings
   with the appropriate values collected in step 1
3) unit tests

[MGMT-10537]