### PR TITLE
Adding the possibility to run a single-package in unit-tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,11 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+TEST ?= ./...
+
 .PHONY: test
 unit-test: manifests generate lint vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TEST) -coverprofile cover.out
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint against code.


### PR DESCRIPTION
In order to run only the `filter` package tests for example, use:
```
make unit-test TEST=github.com/qbarrand/oot-operator/internal/filter
```

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>