### PR TITLE
Use Background context instead of TODO

### DIFF
--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -66,7 +66,7 @@ var _ = Describe("ModuleReconciler", func() {
 				},
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).DoAndReturn(
@@ -95,7 +95,7 @@ var _ = Describe("ModuleReconciler", func() {
 				mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
 			)
 
-			res, err := mr.Reconcile(context.TODO(), req)
+			res, err := mr.Reconcile(context.Background(), req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(reconcile.Result{}))
 		})
@@ -120,7 +120,7 @@ var _ = Describe("ModuleReconciler", func() {
 				},
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).DoAndReturn(
 					func(_ interface{}, _ interface{}, m *ootov1alpha1.Module) error {
@@ -148,7 +148,7 @@ var _ = Describe("ModuleReconciler", func() {
 				mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
 			)
 
-			res, err := mr.Reconcile(context.TODO(), req)
+			res, err := mr.Reconcile(context.Background(), req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(reconcile.Result{}))
 		})
@@ -193,7 +193,7 @@ var _ = Describe("ModuleReconciler", func() {
 				},
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).DoAndReturn(
@@ -232,11 +232,11 @@ var _ = Describe("ModuleReconciler", func() {
 				mockKM.EXPECT().FindMappingForKernel(mappings, kernelVersion).Return(&mappings[0], nil),
 				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
 				mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace),
-				mockDC.EXPECT().SetDriverContainerAsDesired(context.TODO(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion),
+				mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion),
 				mockDC.EXPECT().GarbageCollect(ctx, nil, sets.NewString(kernelVersion)),
 			)
 
-			res, err := mr.Reconcile(context.TODO(), req)
+			res, err := mr.Reconcile(context.Background(), req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(reconcile.Result{}))
 		})
@@ -295,7 +295,7 @@ var _ = Describe("ModuleReconciler", func() {
 				},
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).DoAndReturn(
@@ -331,14 +331,14 @@ var _ = Describe("ModuleReconciler", func() {
 				mockKM.EXPECT().FindMappingForKernel(mappings, kernelVersion).Return(&mappings[0], nil),
 				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
 				mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
-				mockDC.EXPECT().SetDriverContainerAsDesired(context.TODO(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion).Do(
+				mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion).Do(
 					func(ctx context.Context, d *appsv1.DaemonSet, _ string, _ ootov1alpha1.Module, _ string) {
 						d.SetLabels(map[string]string{"test": "test"})
 					}),
 				mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
 			)
 
-			res, err := mr.Reconcile(context.TODO(), req)
+			res, err := mr.Reconcile(context.Background(), req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(reconcile.Result{}))
 		})

--- a/controllers/node_kernel_reconciler_test.go
+++ b/controllers/node_kernel_reconciler_test.go
@@ -31,7 +31,7 @@ var _ = Describe("NodeKernelReconciler", func() {
 		)
 
 		It("should return an error if the node cannot be found anymore", func() {
-			ctx := context.TODO()
+			ctx := context.Background()
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 			nkr := NewNodeKernelReconciler(clnt, labelName, nil)
@@ -51,7 +51,7 @@ var _ = Describe("NodeKernelReconciler", func() {
 				},
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ interface{}, _ interface{}, n *v1.Node) error {
@@ -84,7 +84,7 @@ var _ = Describe("NodeKernelReconciler", func() {
 				},
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ interface{}, _ interface{}, n *v1.Node) error {

--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -65,7 +65,7 @@ var _ = Describe("JobManager", func() {
 		}
 
 		It("should return an error if there was an error getting the image", func() {
-			ctx := context.TODO()
+			ctx := context.Background()
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(gomock.Any(), km).Return(km.Build),
 				getter.EXPECT().ImageExists(ctx, imageName, po).Return(false, errors.New("random error")),
@@ -77,7 +77,7 @@ var _ = Describe("JobManager", func() {
 		})
 
 		It("should return StatusCompleted if the image already exists", func() {
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(gomock.Any(), km).Return(km.Build),
@@ -111,7 +111,7 @@ var _ = Describe("JobManager", func() {
 					},
 					Status: s,
 				}
-				ctx := context.TODO()
+				ctx := context.Background()
 				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ interface{}, list *batchv1.JobList, _ ...interface{}) error {
 						list.Items = []batchv1.Job{j}
@@ -141,7 +141,7 @@ var _ = Describe("JobManager", func() {
 		)
 
 		It("should return an error if there was an error creating the job", func() {
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
@@ -160,7 +160,7 @@ var _ = Describe("JobManager", func() {
 		})
 
 		It("should create the job if there was no error making it", func() {
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			const jobName = "some-job"
 

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -41,7 +41,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.TODO(), nil, "", ootov1alpha1.Module{}, ""),
+			dg.SetDriverContainerAsDesired(context.Background(), nil, "", ootov1alpha1.Module{}, ""),
 		).To(
 			HaveOccurred(),
 		)
@@ -49,7 +49,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the image is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.TODO(), &appsv1.DaemonSet{}, "", ootov1alpha1.Module{}, ""),
+			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", ootov1alpha1.Module{}, ""),
 		).To(
 			HaveOccurred(),
 		)
@@ -57,7 +57,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the kernel version is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.TODO(), &appsv1.DaemonSet{}, "", ootov1alpha1.Module{}, ""),
+			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", ootov1alpha1.Module{}, ""),
 		).To(
 			HaveOccurred(),
 		)
@@ -72,7 +72,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.TODO(), &ds, "test-image", mod, kernelVersion)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
@@ -89,7 +89,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.TODO(), &ds, "test-image", mod, kernelVersion)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(3))
 		Expect(ds.Spec.Template.Spec.Volumes[2]).To(Equal(vol))
@@ -142,7 +142,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDriverContainerAsDesired(context.TODO(), &ds, driverContainerImage, mod, kernelVersion)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, driverContainerImage, mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{
@@ -246,7 +246,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: notLegitName, Namespace: namespace},
 			}
 
-			clnt.EXPECT().Delete(context.TODO(), &dsNotLegit).AnyTimes()
+			clnt.EXPECT().Delete(context.Background(), &dsNotLegit).AnyTimes()
 
 			dc := NewCreator(clnt, "", scheme)
 
@@ -257,13 +257,13 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 			validKernels := sets.NewString(legitKernelVersion)
 
-			res, err := dc.GarbageCollect(context.TODO(), existingDS, validKernels)
+			res, err := dc.GarbageCollect(context.Background(), existingDS, validKernels)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]string{notLegitName}))
 		})
 
 		It("should return an error if a deletion failed", func() {
-			clnt.EXPECT().Delete(context.TODO(), gomock.Any()).Return(
+			clnt.EXPECT().Delete(context.Background(), gomock.Any()).Return(
 				errors.New("client returns some error"),
 			)
 
@@ -273,14 +273,14 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				"some-kernel-version": {},
 			}
 
-			_, err := dc.GarbageCollect(context.TODO(), existingDS, sets.NewString())
+			_, err := dc.GarbageCollect(context.Background(), existingDS, sets.NewString())
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Describe("ModuleDaemonSetsByKernelVersion", func() {
 		It("should return an empty map if no DaemonSets are present", func() {
-			clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any())
+			clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any())
 
 			dc := NewCreator(clnt, kernelLabel, scheme)
 
@@ -291,13 +291,13 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				},
 			}
 
-			m, err := dc.ModuleDaemonSetsByKernelVersion(context.TODO(), mod.Name, mod.Namespace)
+			m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), mod.Name, mod.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m).To(BeEmpty())
 		})
 
 		It("should return an error if two DaemonSets are present for the same kernel", func() {
-			clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+			clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 			dc := NewCreator(clnt, kernelLabel, scheme)
 			mod := ootov1alpha1.Module{
@@ -307,7 +307,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				},
 			}
 
-			_, err := dc.ModuleDaemonSetsByKernelVersion(context.TODO(), mod.Name, mod.Namespace)
+			_, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), mod.Name, mod.Namespace)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -336,7 +336,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				},
 			}
 
-			clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+			clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ interface{}, list *appsv1.DaemonSetList, _ ...interface{}) error {
 					list.Items = append(list.Items, ds1)
 					list.Items = append(list.Items, ds2)
@@ -352,7 +352,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				},
 			}
 
-			m, err := dc.ModuleDaemonSetsByKernelVersion(context.TODO(), mod.Name, mod.Namespace)
+			m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), mod.Name, mod.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m).To(HaveLen(2))
 			Expect(m).To(HaveKeyWithValue(kernelVersion, &ds1))
@@ -366,7 +366,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDevicePluginAsDesired(context.TODO(), nil, &ootov1alpha1.Module{}),
+			dg.SetDevicePluginAsDesired(context.Background(), nil, &ootov1alpha1.Module{}),
 		).To(
 			HaveOccurred(),
 		)
@@ -375,7 +375,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 	It("should return an error if DevicePlugin not set in the Spec", func() {
 		ds := appsv1.DaemonSet{}
 		Expect(
-			dg.SetDevicePluginAsDesired(context.TODO(), &ds, &ootov1alpha1.Module{}),
+			dg.SetDevicePluginAsDesired(context.Background(), &ds, &ootov1alpha1.Module{}),
 		).To(
 			HaveOccurred(),
 		)
@@ -395,7 +395,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDevicePluginAsDesired(context.TODO(), &ds, &mod)
+		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
@@ -403,9 +403,8 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 	It("should work as expected", func() {
 		const (
-			driverContainerImage = "driver-image"
-			dsName               = "ds-name"
-			serviceAccountName   = "some-service-account"
+			dsName             = "ds-name"
+			serviceAccountName = "some-service-account"
 		)
 
 		dcVolMount := v1.VolumeMount{
@@ -448,7 +447,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDevicePluginAsDesired(context.TODO(), &ds, &mod)
+		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod)
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{
@@ -545,7 +544,7 @@ var _ = Describe("GarbageCollect", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: notLegitName, Namespace: namespace},
 		}
 
-		clnt.EXPECT().Delete(context.TODO(), &dsNotLegit).AnyTimes()
+		clnt.EXPECT().Delete(context.Background(), &dsNotLegit).AnyTimes()
 		dc := NewCreator(clnt, "", scheme)
 
 		existingDS := map[string]*appsv1.DaemonSet{
@@ -556,14 +555,14 @@ var _ = Describe("GarbageCollect", func() {
 		validKernels := sets.NewString(legitKernelVersion)
 
 		Expect(
-			dc.GarbageCollect(context.TODO(), existingDS, validKernels),
+			dc.GarbageCollect(context.Background(), existingDS, validKernels),
 		).To(
 			Equal([]string{notLegitName}),
 		)
 	})
 
 	It("should return an error if a deletion failed", func() {
-		clnt.EXPECT().Delete(context.TODO(), gomock.Any()).Return(errors.New("some deleting error"))
+		clnt.EXPECT().Delete(context.Background(), gomock.Any()).Return(errors.New("some deleting error"))
 
 		dc := NewCreator(clnt, "", scheme)
 
@@ -571,7 +570,7 @@ var _ = Describe("GarbageCollect", func() {
 			"some-kernel-version": {},
 		}
 
-		_, err := dc.GarbageCollect(context.TODO(), existingDS, sets.NewString())
+		_, err := dc.GarbageCollect(context.Background(), existingDS, sets.NewString())
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -583,11 +582,11 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 	})
 
 	It("should return an empty map if no DaemonSets are present", func() {
-		clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any())
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any())
 
 		dc := NewCreator(clnt, kernelLabel, scheme)
 
-		m, err := dc.ModuleDaemonSetsByKernelVersion(context.TODO(), moduleName, namespace)
+		m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), moduleName, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(m).To(BeEmpty())
 	})
@@ -614,7 +613,7 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 			},
 		}
 
-		ctx := context.TODO()
+		ctx := context.Background()
 		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ interface{}, list *appsv1.DaemonSetList, _ ...interface{}) error {
 				list.Items = []appsv1.DaemonSet{ds1, ds2}
@@ -652,7 +651,7 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 			},
 		}
 
-		ctx := context.TODO()
+		ctx := context.Background()
 
 		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ interface{}, list *appsv1.DaemonSetList, _ ...interface{}) error {
@@ -692,7 +691,7 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 			},
 		}
 
-		ctx := context.TODO()
+		ctx := context.Background()
 
 		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ interface{}, list *appsv1.DaemonSetList, _ ...interface{}) error {
@@ -703,7 +702,7 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 
 		dc := NewCreator(clnt, kernelLabel, scheme)
 
-		m, err := dc.ModuleDaemonSetsByKernelVersion(context.TODO(), moduleName, namespace)
+		m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), moduleName, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(m).To(HaveLen(1))
 		Expect(m).To(HaveKeyWithValue(kernelVersion, &ds1))

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -236,7 +236,7 @@ var _ = Describe("FindModulesForNode", func() {
 	})
 
 	It("should return nothing if there are no modules", func() {
-		clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any())
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any())
 
 		p := New(clnt, logr.Discard())
 		Expect(
@@ -253,7 +253,7 @@ var _ = Describe("FindModulesForNode", func() {
 			},
 		}
 
-		clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ interface{}, list *ootov1alpha1.ModuleList, _ ...interface{}) error {
 				list.Items = []ootov1alpha1.Module{mod}
 				return nil
@@ -289,7 +289,7 @@ var _ = Describe("FindModulesForNode", func() {
 				Selector: map[string]string{"other-key": "other-value"},
 			},
 		}
-		clnt.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ interface{}, list *ootov1alpha1.ModuleList, _ ...interface{}) error {
 				list.Items = []ootov1alpha1.Module{mod1, mod2}
 				return nil

--- a/internal/module/conditions_test.go
+++ b/internal/module/conditions_test.go
@@ -26,7 +26,7 @@ var _ = Describe("SetAs{Ready,Progressing,Errored}", func() {
 	DescribeTable("Setting one condition to true, should set others to false",
 		func(expectedType string, call func(cu ConditionsUpdater) error) {
 			c := client.NewMockClient(gomock.NewController(GinkgoT()))
-			c.EXPECT().Update(context.TODO(), mod)
+			c.EXPECT().Update(context.Background(), mod)
 
 			cu := NewConditionsUpdater(c)
 


### PR DESCRIPTION
Following the good practices of Golang,
we should use context.Background() function in test files
instead of context.TODO()