### PR TITLE
Allow skipping TLS certificate verification when pulling and pushing

### DIFF
--- a/api/v1alpha1/module_types.go
+++ b/api/v1alpha1/module_types.go
@@ -28,17 +28,23 @@ type BuildArg struct {
 }
 
 type PullOptions struct {
+	// If Insecure is true, images can be pulled from an insecure (plain HTTP) registry.
 	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 
-	// When Insecure is true, images can be pulled from an insecure (plain HTTP) registry.
-	Insecure bool `json:"insecure"`
+	// If InsecureSkipTLSVerify, the operator will accept any certificate provided by the registry.
+	// +optional
+	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 }
 
 type PushOptions struct {
+	// If Insecure is true, built images can be pushed to an insecure (plain HTTP) registry.
 	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 
-	// When Insecure is true, built images can be pushed to an insecure (plain HTTP) registry.
-	Insecure bool `json:"insecure"`
+	// If InsecureSkipTLSVerify, the operator will accept any certificate provided by the registry.
+	// +optional
+	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 }
 
 type Build struct {

--- a/config/crd/bases/ooto.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/ooto.sigs.k8s.io_modules.yaml
@@ -1558,18 +1558,30 @@ spec:
                       the DriverContainer image already exists.
                     properties:
                       insecure:
-                        description: When Insecure is true, images can be pulled from
+                        description: If Insecure is true, images can be pulled from
                           an insecure (plain HTTP) registry.
                         type: boolean
+                      insecureSkipTLSVerify:
+                        description: If InsecureSkipTLSVerify, the operator will accept
+                          any certificate provided by the registry
+                        type: boolean
+                    required:
+                    - insecureSkipTLSVerify
                     type: object
                   push:
                     description: Push contains settings determining how to push a
                       built DriverContainer image.
                     properties:
                       insecure:
-                        description: When Insecure is true, built images can be pushed
+                        description: If Insecure is true, built images can be pushed
                           to an insecure (plain HTTP) registry.
                         type: boolean
+                      insecureSkipTLSVerify:
+                        description: If InsecureSkipTLSVerify, the operator will accept
+                          any certificate provided by the registry
+                        type: boolean
+                    required:
+                    - insecureSkipTLSVerify
                     type: object
                   secrets:
                     description: Secrets is an optional list of secrets to be made
@@ -4012,18 +4024,30 @@ spec:
                             if the DriverContainer image already exists.
                           properties:
                             insecure:
-                              description: When Insecure is true, images can be pulled
+                              description: If Insecure is true, images can be pulled
                                 from an insecure (plain HTTP) registry.
                               type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry
+                              type: boolean
+                          required:
+                          - insecureSkipTLSVerify
                           type: object
                         push:
                           description: Push contains settings determining how to push
                             a built DriverContainer image.
                           properties:
                             insecure:
-                              description: When Insecure is true, built images can
-                                be pushed to an insecure (plain HTTP) registry.
+                              description: If Insecure is true, built images can be
+                                pushed to an insecure (plain HTTP) registry.
                               type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry
+                              type: boolean
+                          required:
+                          - insecureSkipTLSVerify
                           type: object
                         secrets:
                           description: Secrets is an optional list of secrets to be

--- a/internal/build/job/maker.go
+++ b/internal/build/job/maker.go
@@ -44,8 +44,16 @@ func (m *maker) MakeJob(mod ootov1alpha1.Module, buildConfig *ootov1alpha1.Build
 		args = append(args, "--insecure-pull")
 	}
 
+	if buildConfig.Pull.InsecureSkipTLSVerify {
+		args = append(args, "--skip-tls-verify-pull")
+	}
+
 	if buildConfig.Push.Insecure {
 		args = append(args, "--insecure")
+	}
+
+	if buildConfig.Push.InsecureSkipTLSVerify {
+		args = append(args, "--skip-tls-verify")
 	}
 
 	const dockerfileVolumeName = "dockerfile"

--- a/internal/build/job/maker_test.go
+++ b/internal/build/job/maker_test.go
@@ -148,6 +148,38 @@ var _ = Describe("Maker", func() {
 				BeEmpty(),
 			)
 		})
+
+		DescribeTable(
+			"should set correct kaniko flags",
+			func(b ootov1alpha1.Build, flag string) {
+				mh.EXPECT().ApplyBuildArgOverrides(nil, ootov1alpha1.BuildArg{Name: "KERNEL_VERSION", Value: kernelVersion})
+
+				job, err := m.MakeJob(mod, &b, kernelVersion, km.ContainerImage)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElement(flag))
+
+			},
+			Entry(
+				"PullOptions.Insecure",
+				ootov1alpha1.Build{Pull: ootov1alpha1.PullOptions{Insecure: true}},
+				"--insecure-pull",
+			),
+			Entry(
+				"PullOptions.InsecureSkipTLSVerify",
+				ootov1alpha1.Build{Pull: ootov1alpha1.PullOptions{InsecureSkipTLSVerify: true}},
+				"--skip-tls-verify-pull",
+			),
+			Entry(
+				"PushOptions.Insecure",
+				ootov1alpha1.Build{Push: ootov1alpha1.PushOptions{Insecure: true}},
+				"--insecure",
+			),
+			Entry(
+				"PushOptions.InsecureSkipTLSVerify",
+				ootov1alpha1.Build{Push: ootov1alpha1.PushOptions{InsecureSkipTLSVerify: true}},
+				"--skip-tls-verify",
+			),
+		)
 	})
 
 	Describe("MakeSecretVolumes", func() {


### PR DESCRIPTION
This PR brings the `insecureSkipTLSVerify` setting for pull & push options which will disable TLS certificate verification for registries. This option should never be enabled in production.