### PR TITLE
Use k8s.io/utils/pointer to create pointer values in Kubernetes objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	k8s.io/klog/v2 v2.70.0
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.2
 )
 
@@ -30,6 +31,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.16+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -81,13 +84,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-)
-
-require (
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/go-openapi/swag v0.21.1
 )

--- a/internal/build/job/maker.go
+++ b/internal/build/job/maker.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -47,8 +48,6 @@ func (m *maker) MakeJob(mod ootov1alpha1.Module, buildConfig *ootov1alpha1.Build
 		args = append(args, "--insecure")
 	}
 
-	var one int32 = 1
-
 	const dockerfileVolumeName = "dockerfile"
 
 	dockerFileVolume := v1.Volume{
@@ -78,7 +77,7 @@ func (m *maker) MakeJob(mod ootov1alpha1.Module, buildConfig *ootov1alpha1.Build
 			Labels:       labels(mod, targetKernel),
 		},
 		Spec: batchv1.JobSpec{
-			Completions: &one,
+			Completions: pointer.Int32(1),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"Dockerfile": buildConfig.Dockerfile},

--- a/internal/build/job/maker_test.go
+++ b/internal/build/job/maker_test.go
@@ -12,6 +12,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Maker", func() {
@@ -58,11 +59,6 @@ var _ = Describe("Maker", func() {
 		})
 
 		It("should set fields correctly", func() {
-			var (
-				one     int32 = 1
-				trueVar       = true
-			)
-
 			expected := &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: mod.Name + "-build-",
@@ -76,13 +72,13 @@ var _ = Describe("Maker", func() {
 							APIVersion:         "ooto.sigs.k8s.io/v1alpha1",
 							Kind:               "Module",
 							Name:               moduleName,
-							Controller:         &trueVar,
-							BlockOwnerDeletion: &trueVar,
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
 						},
 					},
 				},
 				Spec: batchv1.JobSpec{
-					Completions: &one,
+					Completions: pointer.Int32(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{"Dockerfile": dockerfile},

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-openapi/swag"
 	ootov1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
 	"github.com/qbarrand/oot-operator/internal/constants"
 	appsv1 "k8s.io/api/apps/v1"
@@ -13,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -229,7 +229,7 @@ func (dc *daemonSetGenerator) constructDaemonSet(ctx context.Context,
 		if container.SecurityContext == nil {
 			container.SecurityContext = &v1.SecurityContext{}
 		}
-		container.SecurityContext.Privileged = swag.Bool(true)
+		container.SecurityContext.Privileged = pointer.Bool(true)
 	}
 
 	containers := []v1.Container{container}

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -3,7 +3,6 @@ package daemonset
 import (
 	"context"
 	"errors"
-	"github.com/go-openapi/swag"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -16,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -160,8 +160,8 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         mod.APIVersion,
-						BlockOwnerDeletion: swag.Bool(true),
-						Controller:         swag.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Bool(true),
 						Kind:               mod.Kind,
 						Name:               moduleName,
 						UID:                mod.UID,
@@ -455,7 +455,6 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 		}
 
 		directory := v1.HostPathDirectory
-		trueVar := true
 
 		expected := appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -465,8 +464,8 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         mod.APIVersion,
-						BlockOwnerDeletion: &trueVar,
-						Controller:         &trueVar,
+						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Bool(true),
 						Kind:               mod.Kind,
 						Name:               moduleName,
 						UID:                mod.UID,
@@ -490,7 +489,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 									},
 								},
 								SecurityContext: &v1.SecurityContext{
-									Privileged: swag.Bool(true),
+									Privileged: pointer.Bool(true),
 								},
 							},
 						},


### PR DESCRIPTION
To add pointer values to Kubernetes objects, we were either using an OpenAPI library or manually declaring variables. This PR standardizes around the `k8s.io/utils/pointer` package to generate those values.