### PR TITLE
Do not try to substitute Dockerfile variables

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -388,7 +388,35 @@ jobs:
 
       - name: Check that the DriverContainer prints the secret's value to the standard output
         run: |
-          until kubectl logs -l oot.node.kubernetes.io/module.name | grep super-secret-value; do
+          function check_output {
+            out=$(kubectl logs -l oot.node.kubernetes.io/module.name)
+            if $? -ne 0; then
+              echo 'kubectl failed'
+              return 1;
+            fi
+
+            if ! echo $out | grep super-secret-value; then
+              echo 'secret value not found'
+              return 1
+            fi
+
+            if ! echo $out | grep some-build-arg; then
+              echo 'build argument not found'
+              return 1
+            fi
+
+            if ! echo $out | grep $KERNEL_VERSION; then
+              echo 'kernel version not found'
+              return 1
+            fi
+
+            if ! echo $out | grep default-value; then
+              echo 'build argument with default value not found'
+              return 1
+            fi
+          }
+
+          until check_output; do
             sleep 3
           done
         timeout-minutes: 1

--- a/ci/module-ooto-ci-build.template.yaml
+++ b/ci/module-ooto-ci-build.template.yaml
@@ -10,7 +10,12 @@ spec:
       - sh
       - -c
       # Wrap inside echo to disable stdout buffering
-      - 'echo "Hello World! secret: $(cat /ci-build-secret)" && sleep infinity'
+      - |
+        echo "secret: $(cat /ci-build-secret)"
+        echo "build arg: $(cat /build-arg)"
+        echo "kernel version: $(cat /kernel-version)"
+        echo "default value: $(cat /default-value)"
+        sleep infinity
     lifecycle:
       postStart:
         exec:
@@ -25,6 +30,9 @@ spec:
     - literal: KVER_CHANGEME
       containerImage: registry.minikube/ooto-kmod:local
       build:
+        buildArgs:
+          - name: CI_BUILD_ARG
+            value: some-build-arg
         pull:
           insecure: true
         push:
@@ -33,6 +41,14 @@ spec:
           - name: build-secret
         dockerfile: |
           FROM registry.minikube/ooto-base:local
-          RUN cat /run/secrets/build-secret/ci-build-secret > /ci-build-secret
+
+          ARG CI_BUILD_ARG
+          ARG KERNEL_VERSION
+          ARG WITH_DEFAULT_VALUE=default-value
+
+          RUN cat /run/secrets/build-secret/ci-build-secret > /ci-build-secret          
+          RUN echo $CI_BUILD_ARG > /build-arg
+          RUN echo $KERNEL_VERSION > /kernel-version
+          RUN echo $WITH_DEFAULT_VALUE > /default-value
   selector:
     kubernetes.io/hostname: minikube

--- a/config/crd/bases/ooto.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/ooto.sigs.k8s.io_modules.yaml
@@ -1563,10 +1563,8 @@ spec:
                         type: boolean
                       insecureSkipTLSVerify:
                         description: If InsecureSkipTLSVerify, the operator will accept
-                          any certificate provided by the registry
+                          any certificate provided by the registry.
                         type: boolean
-                    required:
-                    - insecureSkipTLSVerify
                     type: object
                   push:
                     description: Push contains settings determining how to push a
@@ -1578,10 +1576,8 @@ spec:
                         type: boolean
                       insecureSkipTLSVerify:
                         description: If InsecureSkipTLSVerify, the operator will accept
-                          any certificate provided by the registry
+                          any certificate provided by the registry.
                         type: boolean
-                    required:
-                    - insecureSkipTLSVerify
                     type: object
                   secrets:
                     description: Secrets is an optional list of secrets to be made
@@ -4029,10 +4025,8 @@ spec:
                               type: boolean
                             insecureSkipTLSVerify:
                               description: If InsecureSkipTLSVerify, the operator
-                                will accept any certificate provided by the registry
+                                will accept any certificate provided by the registry.
                               type: boolean
-                          required:
-                          - insecureSkipTLSVerify
                           type: object
                         push:
                           description: Push contains settings determining how to push
@@ -4044,10 +4038,8 @@ spec:
                               type: boolean
                             insecureSkipTLSVerify:
                               description: If InsecureSkipTLSVerify, the operator
-                                will accept any certificate provided by the registry
+                                will accept any certificate provided by the registry.
                               type: boolean
-                          required:
-                          - insecureSkipTLSVerify
                           type: object
                         secrets:
                           description: Secrets is an optional list of secrets to be

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -99,7 +99,7 @@ func (k *kernelMapper) PrepareKernelMapping(mapping *ootov1alpha1.KernelMapping,
 	substMapping := mapping.DeepCopy()
 	substMapping.ContainerImage = substContainerImage
 
-	return &substMapping, nil
+	return substMapping, nil
 }
 
 func (k *kernelMapper) prepareOSConfigList(osConfig NodeOSConfig) []string {

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -1,7 +1,6 @@
 package module
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -88,19 +87,19 @@ func (k *kernelMapper) GetNodeOSConfig(node *v1.Node) *NodeOSConfig {
 }
 
 func (k *kernelMapper) PrepareKernelMapping(mapping *ootov1alpha1.KernelMapping, osConfig *NodeOSConfig) (*ootov1alpha1.KernelMapping, error) {
-	mappingString, err := json.Marshal(mapping)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal mapping: %w", err)
-	}
 	osConfigStrings := k.prepareOSConfigList(*osConfig)
+
 	parser := parse.New("mapping", osConfigStrings, &parse.Restrictions{})
-	parsedMapping, err := parser.Parse(string(mappingString))
+
+	substContainerImage, err := parser.Parse(mapping.ContainerImage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to substitute the os config into mapping: %w", err)
+		return nil, fmt.Errorf("failed to substitute the os config into ContainerImage field: %w", err)
 	}
-	substMapping := ootov1alpha1.KernelMapping{}
-	err = json.Unmarshal([]byte(parsedMapping), &substMapping)
-	return &substMapping, err
+
+	substMapping := *mapping
+	substMapping.ContainerImage = substContainerImage
+
+	return &substMapping, nil
 }
 
 func (k *kernelMapper) prepareOSConfigList(osConfig NodeOSConfig) []string {

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -96,7 +96,7 @@ func (k *kernelMapper) PrepareKernelMapping(mapping *ootov1alpha1.KernelMapping,
 		return nil, fmt.Errorf("failed to substitute the os config into ContainerImage field: %w", err)
 	}
 
-	substMapping := *mapping
+	substMapping := mapping.DeepCopy()
 	substMapping.ContainerImage = substContainerImage
 
 	return &substMapping, nil

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -87,27 +87,35 @@ var _ = Describe("PrepareKernelMapping", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("flow with replacement", func() {
+	It("should only substitute the ContainerImage field", func() {
+		const (
+			dockerfile = "RUN echo $MYVAR"
+			literal    = "some literal:${KERNEL_XYZ"
+			regexp     = "some regexp:${KERNEL_XYZ"
+		)
+
 		mapping := ootov1alpha1.KernelMapping{
 			ContainerImage: "some image:${KERNEL_XYZ}",
-			Literal:        "some literal",
-			Regexp:         "regexp",
+			Literal:        literal,
+			Regexp:         regexp,
 			Build: &ootov1alpha1.Build{
 				BuildArgs: []ootov1alpha1.BuildArg{
 					{Name: "name1", Value: "value1"},
 					{Name: "kernel version", Value: "${KERNEL_FULL_VERSION}"},
 				},
+				Dockerfile: dockerfile,
 			},
 		}
 		expectMapping := ootov1alpha1.KernelMapping{
 			ContainerImage: "some image:kernelMMP",
-			Literal:        "some literal",
-			Regexp:         "regexp",
+			Literal:        literal,
+			Regexp:         regexp,
 			Build: &ootov1alpha1.Build{
 				BuildArgs: []ootov1alpha1.BuildArg{
 					{Name: "name1", Value: "value1"},
-					{Name: "kernel version", Value: "kernelFullVersion"},
+					{Name: "kernel version", Value: "${KERNEL_FULL_VERSION}"},
 				},
+				Dockerfile: dockerfile,
 			},
 		}
 


### PR DESCRIPTION
PR #73 introduced variable substitution for kernel mappings. However it tried and replaced everyt string starting with `$` stored in the mapping struct, including in the Dockerfile. That substituted build arguments and environment variables in the Dockerfile with empty strings, breaking builds.
This PR changes the behaviour to only replace variables set in the `ContainerImage` field. If more kernel variables are desired at build time, we should add them as build arguments instead of replacing user-provided strings.
It also adds a check for build arguments in the `In-cluster build` e2e CI workflow.