### PR TITLE
Device Plugin should run only on nodes where Driver Container is running

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -179,6 +179,8 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(ctx context.Context, ds *
 		constants.ModuleNameLabel: mod.Name,
 	}
 
+	nodeSelector := map[string]string{GetDriverContainerNodeLabel(mod.Name): ""}
+
 	containerVolumeMounts := []v1.VolumeMount{
 		{
 			Name:      kubeletDevicePluginsVolumeName,
@@ -200,7 +202,7 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(ctx context.Context, ds *
 	}
 
 	return dc.constructDaemonSet(ctx, ds, mod, *mod.Spec.DevicePlugin, "device-plugin", "", standardLabels,
-		mod.Spec.Selector, containerVolumeMounts, dsVolumes, true)
+		nodeSelector, containerVolumeMounts, dsVolumes, true)
 }
 
 func (dc *daemonSetGenerator) IsDevicePluginDaemonSet(ds appsv1.DaemonSet) bool {
@@ -271,4 +273,8 @@ func CopyMapStringString(m map[string]string) map[string]string {
 	}
 
 	return n
+}
+
+func GetDriverContainerNodeLabel(moduleName string) string {
+	return fmt.Sprintf("oot.node.kubernetes.io/%s.ready", moduleName)
 }

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -494,7 +494,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 							},
 						},
 						NodeSelector: map[string]string{
-							"has-feature-x": "true",
+							GetDriverContainerNodeLabel(mod.Name): "",
 						},
 						ServiceAccountName: serviceAccountName,
 						Volumes: []v1.Volume{


### PR DESCRIPTION
This PR configures the DevicePlugin daemonset to run only on the nodes
that were labeled by the Driver Container daemonset. The labeling of the nodes
code will be added by MGMT-11122

MGMT-11116