### PR TITLE
Adding additional metrics to the KMMO

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -148,7 +148,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("could not garbage collect DaemonSets: %v", err)
 	}
 
-	err = r.statusUpdaterAPI.UpdateModuleStatus(ctx, mod, nodesWithMapping, targetedNodes)
+	err = r.statusUpdaterAPI.UpdateModuleStatus(ctx, mod, nodesWithMapping, targetedNodes, dsByKernelVersion)
 	if err != nil {
 		return res, fmt.Errorf("failed to update status of the module: %w", err)
 	}
@@ -236,6 +236,13 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
 
+	switch buildRes.Status {
+	case build.StatusCreated:
+		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false)
+	case build.StatusCompleted:
+		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true)
+	}
+
 	return buildRes.Requeue, nil
 }
 
@@ -257,9 +264,16 @@ func (r *ModuleReconciler) handleDriverContainer(ctx context.Context,
 		ds.GenerateName = mod.Name + "-"
 	}
 
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, func() error {
+	opRes, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, func() error {
 		return r.daemonAPI.SetDriverContainerAsDesired(ctx, ds, km.ContainerImage, *mod, kernelVersion)
 	})
+
+	if err == nil {
+		if opRes == controllerutil.OperationResultCreated {
+			r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.DriverContainerStage, false)
+		}
+		logger.Info("Reconciled Driver Container", "name", ds.Name, "result", opRes)
+	}
 
 	return err
 }
@@ -285,6 +299,9 @@ func (r *ModuleReconciler) handleDevicePlugin(ctx context.Context, mod *ootov1al
 	})
 
 	if err == nil {
+		if opRes == controllerutil.OperationResultCreated {
+			r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, "", metrics.DevicePluginStage, false)
+		}
 		logger.Info("Reconciled Device Plugin", "name", ds.Name, "result", opRes)
 	}
 

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -24,17 +24,16 @@ const (
 	nodeLibModulesVolumeName       = "node-lib-modules"
 	nodeUsrLibModulesPath          = "/usr/lib/modules"
 	nodeUsrLibModulesVolumeName    = "node-usr-lib-modules"
+	devicePluginKernelVersion      = ""
 )
 
 //go:generate mockgen -source=daemonset.go -package=daemonset -destination=mock_daemonset.go
 
 type DaemonSetCreator interface {
 	GarbageCollect(ctx context.Context, existingDS map[string]*appsv1.DaemonSet, validKernels sets.String) ([]string, error)
-	ModuleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	ModuleDaemonSetsByKernelVersion(ctx context.Context, name, namespace string) (map[string]*appsv1.DaemonSet, error)
 	SetDriverContainerAsDesired(ctx context.Context, ds *appsv1.DaemonSet, image string, mod ootov1alpha1.Module, kernelVersion string) error
 	SetDevicePluginAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mod *ootov1alpha1.Module) error
-	IsDevicePluginDaemonSet(ds appsv1.DaemonSet) bool
 }
 
 type daemonSetGenerator struct {
@@ -67,20 +66,8 @@ func (dc *daemonSetGenerator) GarbageCollect(ctx context.Context, existingDS map
 	return deleted, nil
 }
 
-func (dc *daemonSetGenerator) ModuleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
-	dsList := appsv1.DaemonSetList{}
-	opts := []client.ListOption{
-		client.MatchingLabels(map[string]string{constants.ModuleNameLabel: name}),
-		client.InNamespace(namespace),
-	}
-	if err := dc.client.List(ctx, &dsList, opts...); err != nil {
-		return nil, fmt.Errorf("could not list DaemonSets: %v", err)
-	}
-	return dsList.Items, nil
-}
-
 func (dc *daemonSetGenerator) ModuleDaemonSetsByKernelVersion(ctx context.Context, name, namespace string) (map[string]*appsv1.DaemonSet, error) {
-	dsList, err := dc.ModuleDaemonSets(ctx, name, namespace)
+	dsList, err := dc.moduleDaemonSets(ctx, name, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("could not get all DaemonSets: %w", err)
 	}
@@ -91,11 +78,6 @@ func (dc *daemonSetGenerator) ModuleDaemonSetsByKernelVersion(ctx context.Contex
 		ds := dsList[i]
 
 		kernelVersion := ds.Labels[dc.kernelLabel]
-		if kernelVersion == "" {
-			// this is a device plugin, skipping
-			continue
-		}
-
 		if dsByKernelVersion[kernelVersion] != nil {
 			return nil, fmt.Errorf("multiple DaemonSets found for kernel %q", kernelVersion)
 		}
@@ -205,8 +187,16 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(ctx context.Context, ds *
 		nodeSelector, containerVolumeMounts, dsVolumes, true)
 }
 
-func (dc *daemonSetGenerator) IsDevicePluginDaemonSet(ds appsv1.DaemonSet) bool {
-	return ds.Labels[dc.kernelLabel] == ""
+func (dc *daemonSetGenerator) moduleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
+	dsList := appsv1.DaemonSetList{}
+	opts := []client.ListOption{
+		client.MatchingLabels(map[string]string{constants.ModuleNameLabel: name}),
+		client.InNamespace(namespace),
+	}
+	if err := dc.client.List(ctx, &dsList, opts...); err != nil {
+		return nil, fmt.Errorf("could not list DaemonSets: %v", err)
+	}
+	return dsList.Items, nil
 }
 
 func (dc *daemonSetGenerator) constructDaemonSet(ctx context.Context,
@@ -277,4 +267,12 @@ func CopyMapStringString(m map[string]string) map[string]string {
 
 func GetDriverContainerNodeLabel(moduleName string) string {
 	return fmt.Sprintf("oot.node.kubernetes.io/%s.ready", moduleName)
+}
+
+func IsDevicePluginKernelVersion(kernelVersion string) bool {
+	return kernelVersion == devicePluginKernelVersion
+}
+
+func GetDevicePluginKernelVersion() string {
+	return devicePluginKernelVersion
 }

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -668,7 +668,7 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 		Expect(m).To(HaveKeyWithValue(otherKernelVersion, &ds2))
 	})
 
-	It("should skip a map entry for device plugin", func() {
+	It("should include a map entry for device plugin", func() {
 		ds1 := appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "ds1",
@@ -703,7 +703,8 @@ var _ = Describe("ModuleDaemonSetsByKernelVersion", func() {
 
 		m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), moduleName, namespace)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(m).To(HaveLen(1))
+		Expect(m).To(HaveLen(2))
 		Expect(m).To(HaveKeyWithValue(kernelVersion, &ds1))
+		Expect(m).To(HaveKeyWithValue(devicePluginKernelVersion, &ds2))
 	})
 })

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -52,35 +52,6 @@ func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, existingDS, vali
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, existingDS, validKernels)
 }
 
-// IsDevicePluginDaemonSet mocks base method.
-func (m *MockDaemonSetCreator) IsDevicePluginDaemonSet(ds v1.DaemonSet) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDevicePluginDaemonSet", ds)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsDevicePluginDaemonSet indicates an expected call of IsDevicePluginDaemonSet.
-func (mr *MockDaemonSetCreatorMockRecorder) IsDevicePluginDaemonSet(ds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDevicePluginDaemonSet", reflect.TypeOf((*MockDaemonSetCreator)(nil).IsDevicePluginDaemonSet), ds)
-}
-
-// ModuleDaemonSets mocks base method.
-func (m *MockDaemonSetCreator) ModuleDaemonSets(ctx context.Context, name, namespace string) ([]v1.DaemonSet, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModuleDaemonSets", ctx, name, namespace)
-	ret0, _ := ret[0].([]v1.DaemonSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModuleDaemonSets indicates an expected call of ModuleDaemonSets.
-func (mr *MockDaemonSetCreatorMockRecorder) ModuleDaemonSets(ctx, name, namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModuleDaemonSets", reflect.TypeOf((*MockDaemonSetCreator)(nil).ModuleDaemonSets), ctx, name, namespace)
-}
-
 // ModuleDaemonSetsByKernelVersion mocks base method.
 func (m *MockDaemonSetCreator) ModuleDaemonSetsByKernelVersion(ctx context.Context, name, namespace string) (map[string]*v1.DaemonSet, error) {
 	m.ctrl.T.Helper()

--- a/internal/metrics/mock_metrics_api.go
+++ b/internal/metrics/mock_metrics_api.go
@@ -45,6 +45,18 @@ func (mr *MockMetricsMockRecorder) Register() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockMetrics)(nil).Register))
 }
 
+// SetCompletedStage mocks base method.
+func (m *MockMetrics) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCompletedStage", kmmoName, kmmoNamespace, kernelVersion, stage, completed)
+}
+
+// SetCompletedStage indicates an expected call of SetCompletedStage.
+func (mr *MockMetricsMockRecorder) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage, completed interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCompletedStage", reflect.TypeOf((*MockMetrics)(nil).SetCompletedStage), kmmoName, kmmoNamespace, kernelVersion, stage, completed)
+}
+
 // SetExistingKMMOModules mocks base method.
 func (m *MockMetrics) SetExistingKMMOModules(value int) {
 	m.ctrl.T.Helper()

--- a/internal/module/mock_statusupdater.go
+++ b/internal/module/mock_statusupdater.go
@@ -10,7 +10,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
+	v10 "k8s.io/api/core/v1"
 )
 
 // MockStatusUpdater is a mock of StatusUpdater interface.
@@ -37,15 +38,15 @@ func (m *MockStatusUpdater) EXPECT() *MockStatusUpdaterMockRecorder {
 }
 
 // UpdateModuleStatus mocks base method.
-func (m *MockStatusUpdater) UpdateModuleStatus(ctx context.Context, mod *v1alpha1.Module, kernelMappingNodes, targetedNodes []v1.Node) error {
+func (m *MockStatusUpdater) UpdateModuleStatus(ctx context.Context, mod *v1alpha1.Module, kernelMappingNodes, targetedNodes []v10.Node, dsByKernelVersion map[string]*v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateModuleStatus", ctx, mod, kernelMappingNodes, targetedNodes)
+	ret := m.ctrl.Call(m, "UpdateModuleStatus", ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateModuleStatus indicates an expected call of UpdateModuleStatus.
-func (mr *MockStatusUpdaterMockRecorder) UpdateModuleStatus(ctx, mod, kernelMappingNodes, targetedNodes interface{}) *gomock.Call {
+func (mr *MockStatusUpdaterMockRecorder) UpdateModuleStatus(ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateModuleStatus", reflect.TypeOf((*MockStatusUpdater)(nil).UpdateModuleStatus), ctx, mod, kernelMappingNodes, targetedNodes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateModuleStatus", reflect.TypeOf((*MockStatusUpdater)(nil).UpdateModuleStatus), ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion)
 }

--- a/internal/module/statusupdater.go
+++ b/internal/module/statusupdater.go
@@ -2,10 +2,11 @@ package module
 
 import (
 	"context"
-	"fmt"
 
 	ootov1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
 	"github.com/qbarrand/oot-operator/internal/daemonset"
+	"github.com/qbarrand/oot-operator/internal/metrics"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -13,33 +14,39 @@ import (
 //go:generate mockgen -source=statusupdater.go -package=module -destination=mock_statusupdater.go
 
 type StatusUpdater interface {
-	UpdateModuleStatus(ctx context.Context, mod *ootov1alpha1.Module, kernelMappingNodes []v1.Node, targetedNodes []v1.Node) error
+	UpdateModuleStatus(ctx context.Context,
+		mod *ootov1alpha1.Module,
+		kernelMappingNodes []v1.Node,
+		targetedNodes []v1.Node,
+		dsByKernelVersion map[string]*appsv1.DaemonSet) error
 }
 
 type statusUpdater struct {
-	client    client.Client
-	daemonAPI daemonset.DaemonSetCreator
+	client     client.Client
+	daemonAPI  daemonset.DaemonSetCreator
+	metricsAPI metrics.Metrics
 }
 
-func NewStatusUpdater(client client.Client, daemonAPI daemonset.DaemonSetCreator) StatusUpdater {
+func NewStatusUpdater(client client.Client, daemonAPI daemonset.DaemonSetCreator, metricsAPI metrics.Metrics) StatusUpdater {
 	return &statusUpdater{
-		client:    client,
-		daemonAPI: daemonAPI,
+		client:     client,
+		daemonAPI:  daemonAPI,
+		metricsAPI: metricsAPI,
 	}
 }
 
-func (s *statusUpdater) UpdateModuleStatus(ctx context.Context, mod *ootov1alpha1.Module, kernelMappingNodes []v1.Node, targetedNodes []v1.Node) error {
-	dsList, err := s.daemonAPI.ModuleDaemonSets(ctx, mod.Name, mod.Namespace)
-	if err != nil {
-		return fmt.Errorf("failed to get all module's daemonsets: %w", err)
-	}
-	original := mod.DeepCopy()
+func (s *statusUpdater) UpdateModuleStatus(ctx context.Context,
+	mod *ootov1alpha1.Module,
+	kernelMappingNodes []v1.Node,
+	targetedNodes []v1.Node,
+	dsByKernelVersion map[string]*appsv1.DaemonSet) error {
+
 	nodesMatchingSelectorNumber := int32(len(targetedNodes))
 	numDesired := int32(len(kernelMappingNodes))
 	var numAvailableDevicePlugin int32
 	var numAvailableKernelModule int32
-	for _, ds := range dsList {
-		if s.daemonAPI.IsDevicePluginDaemonSet(ds) {
+	for kernelVersion, ds := range dsByKernelVersion {
+		if daemonset.IsDevicePluginKernelVersion(kernelVersion) {
 			numAvailableDevicePlugin += ds.Status.NumberAvailable
 		} else {
 			numAvailableKernelModule += ds.Status.NumberAvailable
@@ -53,5 +60,20 @@ func (s *statusUpdater) UpdateModuleStatus(ctx context.Context, mod *ootov1alpha
 		mod.Status.DevicePlugin.DesiredNumber = numDesired
 		mod.Status.DevicePlugin.AvailableNumber = numAvailableDevicePlugin
 	}
-	return s.client.Status().Patch(ctx, mod, client.MergeFrom(original))
+	s.updateMetrics(ctx, mod, dsByKernelVersion)
+	return s.client.Status().Update(ctx, mod)
+}
+
+func (s *statusUpdater) updateMetrics(ctx context.Context, mod *ootov1alpha1.Module, dsByKernelVersion map[string]*appsv1.DaemonSet) {
+	for kernelVersion, ds := range dsByKernelVersion {
+		stage := metrics.DriverContainerStage
+		if daemonset.IsDevicePluginKernelVersion(kernelVersion) {
+			stage = metrics.DevicePluginStage
+		}
+		s.metricsAPI.SetCompletedStage(mod.Name,
+			mod.Namespace,
+			kernelVersion,
+			stage,
+			ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable)
+	}
 }

--- a/internal/module/statusupdater_test.go
+++ b/internal/module/statusupdater_test.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -9,10 +10,17 @@ import (
 	ootov1alpha1 "github.com/qbarrand/oot-operator/api/v1alpha1"
 	"github.com/qbarrand/oot-operator/internal/client"
 	"github.com/qbarrand/oot-operator/internal/daemonset"
+	"github.com/qbarrand/oot-operator/internal/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type daemonSetConfig struct {
+	desiredNumber   int
+	numberAvailable int
+	isDevicePlugin  bool
+}
 
 var _ = Describe("status update", func() {
 	const (
@@ -21,71 +29,114 @@ var _ = Describe("status update", func() {
 	)
 
 	var (
-		ctrl   *gomock.Controller
-		clnt   *client.MockClient
-		mockDC *daemonset.MockDaemonSetCreator
-		mod    *ootov1alpha1.Module
-		su     StatusUpdater
+		ctrl        *gomock.Controller
+		clnt        *client.MockClient
+		mockDC      *daemonset.MockDaemonSetCreator
+		mockMetrics *metrics.MockMetrics
+		mod         *ootov1alpha1.Module
+		su          StatusUpdater
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mockDC = daemonset.NewMockDaemonSetCreator(ctrl)
+		mockMetrics = metrics.NewMockMetrics(ctrl)
 		mod = &ootov1alpha1.Module{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
-		su = NewStatusUpdater(clnt, mockDC)
+		su = NewStatusUpdater(clnt, mockDC, mockMetrics)
 	})
 
 	DescribeTable("checking status updater based on module",
-		func(mappingsNodes []v1.Node, targetedNodes []v1.Node, ds []appsv1.DaemonSet, moduleAvailable, pluginAvailable int, devicePluginPresent bool) {
+		func(mappingsNodes []v1.Node, targetedNodes []v1.Node, dsMap map[string]*appsv1.DaemonSet, devicePluginPresent bool) {
 			if devicePluginPresent {
 				mod.Spec.DevicePlugin = &v1.Container{}
 			}
-			mockDC.EXPECT().ModuleDaemonSets(context.Background(), name, namespace).Return(ds, nil)
-			mockDC.EXPECT().IsDevicePluginDaemonSet(gomock.Any()).
-				DoAndReturn(func(ds appsv1.DaemonSet) bool {
-					if ds.Name == "device-plugin" {
-						return true
-					} else {
-						return false
-					}
-				}).Times(len(ds))
+			var driverContainerAvailable int32
+			var devicePluginAvailable int32
 
+			for kernelVersion, ds := range dsMap {
+				if daemonset.IsDevicePluginKernelVersion(kernelVersion) {
+					devicePluginAvailable = ds.Status.NumberAvailable
+					mockMetrics.EXPECT().SetCompletedStage(name,
+						namespace,
+						daemonset.GetDevicePluginKernelVersion(),
+						metrics.DevicePluginStage,
+						ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled)
+				} else {
+					driverContainerAvailable += ds.Status.NumberAvailable
+					mockMetrics.EXPECT().SetCompletedStage(name,
+						namespace,
+						kernelVersion,
+						metrics.DriverContainerStage,
+						ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled)
+				}
+			}
 			statusWrite := client.NewMockStatusWriter(ctrl)
 			clnt.EXPECT().Status().Return(statusWrite)
-			statusWrite.EXPECT().Patch(context.Background(), mod, gomock.Any()).Return(nil)
+			statusWrite.EXPECT().Update(context.Background(), mod).Return(nil)
 
-			res := su.UpdateModuleStatus(context.Background(), mod, mappingsNodes, targetedNodes)
+			res := su.UpdateModuleStatus(context.Background(), mod, mappingsNodes, targetedNodes, dsMap)
 
 			Expect(res).To(BeNil())
 			Expect(mod.Status.DriverContainer.NodesMatchingSelectorNumber).To(Equal(int32(len(targetedNodes))))
 			Expect(mod.Status.DriverContainer.DesiredNumber).To(Equal(int32(len(mappingsNodes))))
-			Expect(mod.Status.DriverContainer.AvailableNumber).To(Equal(int32(moduleAvailable)))
-			Expect(mod.Status.DevicePlugin.AvailableNumber).To(Equal(int32(pluginAvailable)))
+			Expect(mod.Status.DriverContainer.AvailableNumber).To(Equal(driverContainerAvailable))
+			Expect(mod.Status.DevicePlugin.AvailableNumber).To(Equal(devicePluginAvailable))
 		},
 		Entry("0 nodes, 0 driver-containers, 0 device plugins",
-			[]v1.Node{}, []v1.Node{}, []appsv1.DaemonSet{}, 0, 0, false,
+			[]v1.Node{},
+			[]v1.Node{},
+			prepareDsByKernel([]daemonSetConfig{}),
+			false,
 		),
 		Entry("2 nodes, 2 driver-containers, 0 device plugins",
-			[]v1.Node{v1.Node{}, v1.Node{}}, []v1.Node{v1.Node{}, v1.Node{}}, []appsv1.DaemonSet{getDaemonSet(2, false), getDaemonSet(3, false)}, 5, 0, false,
+			[]v1.Node{v1.Node{}, v1.Node{}},
+			[]v1.Node{v1.Node{}, v1.Node{}},
+			prepareDsByKernel([]daemonSetConfig{
+				daemonSetConfig{desiredNumber: 2, numberAvailable: 2, isDevicePlugin: false},
+				daemonSetConfig{desiredNumber: 3, numberAvailable: 2, isDevicePlugin: false},
+			}),
+			false,
 		),
 		Entry("2 nodes, 1 driver-containers, 1 device plugins",
-			[]v1.Node{v1.Node{}, v1.Node{}}, []v1.Node{v1.Node{}, v1.Node{}}, []appsv1.DaemonSet{getDaemonSet(2, false), getDaemonSet(3, true)}, 2, 3, true,
+			[]v1.Node{v1.Node{}, v1.Node{}},
+			[]v1.Node{v1.Node{}, v1.Node{}},
+			prepareDsByKernel([]daemonSetConfig{
+				daemonSetConfig{desiredNumber: 4, numberAvailable: 2, isDevicePlugin: true},
+			}),
+			true,
 		),
 		Entry("2 nodes, 3 targeted nodes, 1 driver-containers, 1 device plugins",
-			[]v1.Node{v1.Node{}, v1.Node{}}, []v1.Node{v1.Node{}, v1.Node{}, v1.Node{}}, []appsv1.DaemonSet{getDaemonSet(2, false), getDaemonSet(3, true)}, 2, 3, true,
+			[]v1.Node{v1.Node{}, v1.Node{}},
+			[]v1.Node{v1.Node{}, v1.Node{}, v1.Node{}},
+			prepareDsByKernel([]daemonSetConfig{
+				daemonSetConfig{desiredNumber: 4, numberAvailable: 4, isDevicePlugin: true},
+				daemonSetConfig{desiredNumber: 4, numberAvailable: 2, isDevicePlugin: false},
+			}),
+			true,
 		),
 	)
 })
 
-func getDaemonSet(numberAvailable int, devicePluginFlag bool) appsv1.DaemonSet {
-	name := "driver-container"
-	if devicePluginFlag {
-		name = "device-plugin"
+func getDaemonSet(kernelNumber int, dsConfig daemonSetConfig) (string, *appsv1.DaemonSet) {
+	kernelVersion := fmt.Sprintf("kernel-version-%d", kernelNumber)
+	if dsConfig.isDevicePlugin {
+		kernelVersion = daemonset.GetDevicePluginKernelVersion()
 	}
 	ds := appsv1.DaemonSet{
-		Status: appsv1.DaemonSetStatus{NumberAvailable: int32(numberAvailable)},
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        int32(dsConfig.numberAvailable),
+			DesiredNumberScheduled: int32(dsConfig.numberAvailable),
+		},
 	}
-	ds.Name = name
-	return ds
+	return kernelVersion, &ds
+}
+
+func prepareDsByKernel(dsConfigs []daemonSetConfig) map[string]*appsv1.DaemonSet {
+	dsMap := make(map[string]*appsv1.DaemonSet)
+	for i, dsConfig := range dsConfigs {
+		kernelVersion, ds := getDaemonSet(i, dsConfig)
+		dsMap[kernelVersion] = ds
+	}
+	return dsMap
 }

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 	buildAPI := job.NewBuildManager(client, registryAPI, makerAPI, helperAPI)
 	daemonAPI := daemonset.NewCreator(client, kernelLabel, scheme)
 	kernelAPI := module.NewKernelMapper()
-	statusUpdaterAPI := module.NewStatusUpdater(client, daemonAPI)
+	statusUpdaterAPI := module.NewStatusUpdater(client, daemonAPI, metricsAPI)
 
 	mc := controllers.NewModuleReconciler(client, buildAPI, daemonAPI, kernelAPI, metricsAPI, filter, statusUpdaterAPI)
 


### PR DESCRIPTION
1) metric that reports the status of the stages of KMMO CR:
   build ( completed or not), driver container (completed or not), device plugin( completed or not)
2) metric that reports the targeted nodes ( by label seclector), the nodes that driver container
   will run on, based on label selector and kernel mapping) and the nodes that the driver container
   has currently been deployed to
3) changing the status update from Patch to Update

MGMT-10859