### PR TITLE
Always reconcile pods being deleted

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -48,6 +48,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/qbarrand/oot-operator-catalog
+          sep-tags: ' '
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -104,11 +105,9 @@ jobs:
 
       - name: Build and push catalog
         run: |
-          TAGS=$(echo "${{ steps.meta-catalog.outputs.tags }}" | tr '\n' ' ' | awk '{$1=$1};1')
-
-          for tag in $TAGS; do
+          for tag in ${{ steps.meta-catalog.outputs.tags }}; do
             export CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
-            make catalog-build && make catalog-push
+            make catalog-build catalog-push CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
           done
         env:
           BUNDLE_IMG: ghcr.io/qbarrand/oot-operator-bundle@${{ steps.build-push-bundle.outputs.digest }}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -104,6 +104,8 @@ jobs:
 
       - name: Build and push catalog
         run: |
+          echo ${{ steps.meta-catalog.outputs.tags }}
+          echo "${{ steps.meta-catalog.outputs.tags }}"
           for tag in ${{ steps.meta-catalog.outputs.tags }}; do
             export CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
             make catalog-build && make catalog-push

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -103,7 +103,10 @@ jobs:
           labels: ${{ steps.meta-bundle.outputs.labels }}
 
       - name: Build and push catalog
-        run: make catalog-build && make catalog-push
+        run: |
+          for tag in ${{ steps.meta-catalog.outputs.tags }}; do
+            export CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
+            make catalog-build && make catalog-push
+          done
         env:
           BUNDLE_IMG: ghcr.io/qbarrand/oot-operator-bundle@${{ steps.build-push-bundle.outputs.digest }}
-          VERSION: ${{ github.ref_name }}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -105,10 +105,11 @@ jobs:
 
       - name: Build and push catalog
         run: |
-          echo "${{ steps.meta-catalog.outputs.tags }}"
-          echo ${{ steps.meta-catalog.outputs.tags }}
+          cat >tags <<EOF
+          ${{ steps.meta-catalog.outputs.tags }}
+          EOF
 
-          for img in ${{ steps.meta-catalog.outputs.tags }}; do
+          for img in $(cat tags); do
             make catalog-build catalog-push CATALOG_IMG=$img
           done
         env:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['*']
     branches: [main]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-push:
@@ -21,6 +24,7 @@ jobs:
           images: ghcr.io/qbarrand/oot-operator
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -33,6 +37,7 @@ jobs:
           images: ghcr.io/qbarrand/oot-operator-bundle
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -45,6 +50,7 @@ jobs:
           images: ghcr.io/qbarrand/oot-operator-catalog
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -104,9 +104,9 @@ jobs:
 
       - name: Build and push catalog
         run: |
-          echo ${{ steps.meta-catalog.outputs.tags }}
-          echo "${{ steps.meta-catalog.outputs.tags }}"
-          for tag in ${{ steps.meta-catalog.outputs.tags }}; do
+          TAGS=$(echo "${{ steps.meta-catalog.outputs.tags }}" | tr '\n' ' ' | awk '{$1=$1};1')
+
+          for tag in $TAGS; do
             export CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
             make catalog-build && make catalog-push
           done

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -105,9 +105,11 @@ jobs:
 
       - name: Build and push catalog
         run: |
-          for tag in ${{ steps.meta-catalog.outputs.tags }}; do
-            export CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
-            make catalog-build catalog-push CATALOG_IMG=ghcr.io/qbarrand/oot-operator:$tag
+          echo "${{ steps.meta-catalog.outputs.tags }}"
+          echo ${{ steps.meta-catalog.outputs.tags }}
+
+          for img in ${{ steps.meta-catalog.outputs.tags }}; do
+            make catalog-build catalog-push CATALOG_IMG=$img
           done
         env:
           BUNDLE_IMG: ghcr.io/qbarrand/oot-operator-bundle@${{ steps.build-push-bundle.outputs.digest }}

--- a/controllers/pod_node_module_reconciler.go
+++ b/controllers/pod_node_module_reconciler.go
@@ -88,8 +88,11 @@ func (pnmr *PodNodeModuleReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // SetupWithManager sets up the controller with the Manager.
 func (pnmr *PodNodeModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	p := predicate.And(
-		filter.PodReadinessChangedPredicate(
-			mgr.GetLogger().WithName("pod-readiness-changed"),
+		predicate.Or(
+			filter.PodReadinessChangedPredicate(
+				mgr.GetLogger().WithName("pod-readiness-changed"),
+			),
+			filter.DeletingPredicate(),
 		),
 		filter.HasLabel(constants.ModuleNameLabel),
 		filter.PodHasSpecNodeName(),

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -107,6 +107,13 @@ func (f *Filter) FindModulesForNode(node client.Object) []reconcile.Request {
 	return reqs
 }
 
+// DeletingPredicate returns a predicate that returns true if the object is being deleted.
+func DeletingPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return !object.GetDeletionTimestamp().IsZero()
+	})
+}
+
 // PodHasSpecNodeName returns a predicate that returns true if the object is a *v1.Pod and its .spec.nodeName
 // property is set.
 func PodHasSpecNodeName() predicate.Predicate {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -307,6 +307,22 @@ var _ = Describe("FindModulesForNode", func() {
 	})
 })
 
+var _ = Describe("DeletingPredicate", func() {
+	now := metav1.Now()
+
+	DescribeTable("should return the expected value",
+		func(o client.Object, expected bool) {
+			Expect(
+				DeletingPredicate().Generic(event.GenericEvent{Object: o}),
+			).To(
+				Equal(expected),
+			)
+		},
+		Entry(nil, &v1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}}, true),
+		Entry(nil, &v1.Pod{}, false),
+	)
+})
+
 var _ = Describe("PodHasSpecNodeName", func() {
 	p := PodHasSpecNodeName()
 


### PR DESCRIPTION
Because we only reconciled pod that had their `Ready` condition changed, we would never remove the finalizer on pods that never become `Ready`.

This PR also makes the CI build container images for each PR for easier testing.