### PR TITLE
Remove file generation and linter from `unit-test` makefile target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ vet: ## Run go vet against code.
 TEST ?= ./...
 
 .PHONY: test
-unit-test: manifests generate lint vet envtest ## Run tests.
+unit-test: vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TEST) -coverprofile cover.out
 
 .PHONY: lint


### PR DESCRIPTION
Golang test has it own internal linter which will fail the UTs if there
are some basic lint errors and having that linter overhead when writing
UTs and continuously running them is a pain.

Same apply for files generation. If mocks and the CRD aren't up to date,
UTs will fail anyway.

All those targets are tested in CI anyway so we won't forget it, this is
just a matter of convenient when writing UTs.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>