### PR TITLE
Add a toleration allowing the manager pod to run on master nodes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,3 +61,7 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Equal
+          effect: NoSchedule


### PR DESCRIPTION
Together with the selector that runs the manager on master nodes, we need a toleration allowing it to run on tainted nodes.