### PR TITLE
Add CRD and e2e step test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -133,6 +133,13 @@ jobs:
           done
         timeout-minutes: 1
 
+      - name: Check that the daemon-set for device plugin is running
+        run: |
+          until kubectl get ds  -l 'kmm.node.kubernetes.io/module.name=ooto-ci,kmm.node.kubernetes.io/role=device-plugin' -ojson | jq -e '.items[] | select(.status.numberReady == 1)'; do 
+            sleep 3
+          done
+        timeout-minutes: 1
+
       - name: Remove the Module
         run: kubectl delete -f module-ooto-ci.yaml
 
@@ -267,7 +274,7 @@ jobs:
       - name: Verify that the DaemonSet gets garbage collected
         run: |
           # Cannot use kubectl wait because it will fail if there is no initial match
-          until [ $(kubectl get daemonsets.apps -l kmm.node.kubernetes.io/module.name=ooto-ci-b -o go-template='{{ len .items }}') -eq 0 ]; do
+          until [ $(kubectl get daemonsets.apps -l 'kmm.node.kubernetes.io/module.name=ooto-ci-b, kmm.node.kubernetes.io/role!=device-plugin' -o go-template='{{ len .items }}') -eq 0 ]; do
             sleep 3
           done
         timeout-minutes: 1

--- a/ci/module-ooto-ci.template.yaml
+++ b/ci/module-ooto-ci.template.yaml
@@ -12,5 +12,18 @@ spec:
       kernelMappings:
         - literal: KVER_CHANGEME
           containerImage: ooto-kmod:local
+  devicePlugin:
+    container:
+      image: squat/generic-device-plugin
+      args:
+        - --device
+        - '{"name": "simple-kmod", "groups": [{"paths": [{"path": "/proc/simple-procfs-kmod"}]}]}'
+      volumeMounts:
+        - name: proc
+          mountPath: /proc
+    volumes:
+      - name: proc
+        hostPath:
+          path: /proc
   selector:
     wants-oot-module: KMOD_CHANGEME

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,4 +4,5 @@ const (
 	ModuleNameLabel      = "kmm.node.kubernetes.io/module.name"
 	NodeLabelerFinalizer = "kmm.node.kubernetes.io/node-labeler"
 	TargetKernelTarget   = "kmm.node.kubernetes.io/target-kernel"
+	DaemonSetRole        = "kmm.node.kubernetes.io/role"
 )

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -105,6 +105,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 	standardLabels := map[string]string{
 		constants.ModuleNameLabel: mod.Name,
 		dc.kernelLabel:            kernelVersion,
+		constants.DaemonSetRole:   "module-loader",
 	}
 
 	ds.SetLabels(
@@ -220,7 +221,10 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(ctx context.Context, ds *
 		},
 	}
 
-	standardLabels := map[string]string{constants.ModuleNameLabel: mod.Name}
+	standardLabels := map[string]string{
+		constants.ModuleNameLabel: mod.Name,
+		constants.DaemonSetRole:   "device-plugin",
+	}
 
 	ds.SetLabels(
 		OverrideLabels(ds.GetLabels(), standardLabels),

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -121,6 +121,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 		podLabels := map[string]string{
 			constants.ModuleNameLabel: moduleName,
 			kernelLabel:               kernelVersion,
+			constants.DaemonSetRole:   "module-loader",
 		}
 
 		directory := v1.HostPathDirectory
@@ -430,6 +431,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 		podLabels := map[string]string{
 			constants.ModuleNameLabel: moduleName,
+			constants.DaemonSetRole:   "device-plugin",
 		}
 
 		directory := v1.HostPathDirectory


### PR DESCRIPTION
Add e2e test covering the device plugin management.

Added new labels to distinguish the two different
daemonset types for filtering later on the e2e test.

MGMT-10538