### PR TITLE
Rename CI scripts

### DIFF
--- a/ci/prow/lint
+++ b/ci/prow/lint
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-set -e
+set -euxo pipefail
 
 make lint

--- a/ci/prow/unit-tests
+++ b/ci/prow/unit-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-set -e
+set -euxo pipefail
 
 make unit-test


### PR DESCRIPTION
Rename CI scripts to use hyphens. Use more bash options.