### PR TITLE
Add toleration key for new label node-role.kubernetes.io/control-plane

### DIFF
--- a/ci/install-ci/kustomization.yaml
+++ b/ci/install-ci/kustomization.yaml
@@ -9,16 +9,6 @@ images:
     newName: ooto
     newTag: local
 
-patchesJson6902:
-  - target:
-      version: v1
-      kind: Deployment
-      name: controller-manager
-      namespace: system
-    patch: |-
-      - op: remove
-        path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1master
-
 patchesStrategicMerge:
   - |
     apiVersion: apps/v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,8 +24,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ''
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       securityContext:
         runAsNonRoot: true
       containers:
@@ -63,5 +71,8 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/master
+          operator: Equal
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           operator: Equal
           effect: NoSchedule


### PR DESCRIPTION
From Kubernetes [v1.20](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md) label "node-role.kubernetes.io/master" is deprecated and "node-role.kubernetes.io/control-plane" will be  used instead.
Adding new toleration key to controller to accept both until the definitive removal of the old label.